### PR TITLE
Api: Minimal `TextEncoder` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +907,7 @@ dependencies = [
 name = "jstz_api"
 version = "0.1.0"
 dependencies = [
+ "base64 0.21.4",
  "boa_engine",
  "boa_gc",
  "bytes",
@@ -994,7 +1001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.13.1",
  "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",

--- a/examples/encoding.js
+++ b/examples/encoding.js
@@ -1,0 +1,24 @@
+function encodeDecode(str) {
+  console.log(`encoding "${str}"`);
+  let b64 = TextEncoder.btoa(str);
+  console.info(b64);
+  console.log(`decoding "${b64}"`);
+  let back = TextEncoder.atob(b64);
+  console.info(back);
+}
+
+export default () => {
+  let test_string;
+  let test_strings =
+    ["hello world"
+     , JSON.stringify({foo: "bar"})
+     , "👋 from JSꜩ 🎉"
+    ];
+  try {
+    test_strings.forEach((str) => { test_string = str; encodeDecode(str)});
+  } catch (error){
+    console.error(`error decoding ${test_string}: ${error}`);
+    throw error;
+  }
+  return new Response("Success!")
+}

--- a/jstz_api/Cargo.toml
+++ b/jstz_api/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
+base64 = "0.21.4"
 boa_engine = "0.17.0"
 boa_gc = "0.17.0"
 bytes = "1.4.0"

--- a/jstz_api/src/lib.rs
+++ b/jstz_api/src/lib.rs
@@ -2,6 +2,8 @@ mod console;
 mod kv;
 
 pub mod http;
+mod text_encoder;
 pub mod url;
 pub use console::ConsoleApi;
 pub use kv::KvApi;
+pub use text_encoder::TextEncoderApi;

--- a/jstz_api/src/text_encoder.rs
+++ b/jstz_api/src/text_encoder.rs
@@ -1,0 +1,65 @@
+use std::error::Error;
+
+use base64::prelude::{Engine as _, BASE64_URL_SAFE as DEFAULT_ENGINE};
+use boa_engine::{
+    object::ObjectInitializer, property::Attribute, Context, JsArgs, JsError,
+    JsNativeError, JsResult, JsString, JsValue, NativeFunction,
+};
+use boa_gc::{Finalize, Trace};
+
+#[derive(Trace, Finalize)]
+struct TextEncoder;
+
+impl TextEncoder {
+    fn atob(data: &JsString) -> JsResult<JsString> {
+        fn on_err(err: impl Error) -> JsError {
+            JsNativeError::eval()
+                .with_message(err.to_string())
+                .into()
+        }
+        let str = data.to_std_string_escaped();
+        let encoded = DEFAULT_ENGINE.decode(&str).map_err(on_err)?;
+        let encoded_str = core::str::from_utf8(encoded.as_slice()).map_err(on_err)?;
+
+        Ok(encoded_str.into())
+    }
+    fn btoa(data: &JsString) -> JsResult<JsString> {
+        let str = data.to_std_string_escaped();
+        let encoded = DEFAULT_ENGINE.encode(&str);
+        Ok(encoded.into())
+    }
+}
+
+pub struct TextEncoderApi;
+impl TextEncoderApi {
+    const NAME: &str = "TextEncoder";
+    fn atob(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        let data = args
+            .get_or_undefined(0)
+            .as_string()
+            .ok_or_else(|| JsNativeError::typ().with_message("expected string"))?;
+        let result = TextEncoder::atob(data)?;
+        Ok(result.into())
+    }
+    fn btoa(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        let data = args
+            .get_or_undefined(0)
+            .as_string()
+            .ok_or_else(|| JsNativeError::typ().with_message("expected string"))?;
+        let result = TextEncoder::btoa(data)?;
+        Ok(result.into())
+    }
+}
+
+impl jstz_core::Api for TextEncoderApi {
+    fn init(self, context: &mut boa_engine::Context<'_>) {
+        let encoding = ObjectInitializer::with_native(TextEncoder, context)
+            .function(NativeFunction::from_fn_ptr(Self::atob), "atob", 0)
+            .function(NativeFunction::from_fn_ptr(Self::btoa), "btoa", 0)
+            .build();
+
+        context
+            .register_global_property(Self::NAME, encoding, Attribute::all())
+            .expect("TextEncoder api should only be registered once!")
+    }
+}

--- a/jstz_proto/src/executor/contract.rs
+++ b/jstz_proto/src/executor/contract.rs
@@ -133,6 +133,8 @@ impl Script {
             .register_api(api::ContractApi { contract_address }, context);
         self.realm().register_api(jstz_api::url::UrlApi, context);
         self.realm().register_api(jstz_api::http::HttpApi, context);
+        self.realm()
+            .register_api(jstz_api::TextEncoderApi, context);
     }
 
     /// Initialize the script, registering all associated runtime APIs


### PR DESCRIPTION
# Context
In order to pass Json parameters with in a get request it is common to encode the stringified JSON in base 64.
This PR implements the `btoa` and `atob` functions from the [Deno](https://deno.land/api@v1.36.4?s=atob) `TextEncoder` api to allow json parameters to be passed.

[M5 Demo](https://app.asana.com/0/1205170694555856/1205170694556045/) 

# Manually testing the PR
```
eval `./scripts/sandbox.sh`
tz4=tz4...
jstz deploy-contract --self-address $tz4 < examples/encoding.js
# copy contract address
tzContract=$(pbpaste)
jstz run-contract --referer $tz4 tezos://${tzContract}
```