### PR TITLE
Examples: Update examples to use `Request` and `Response`s

### DIFF
--- a/examples/counter.js
+++ b/examples/counter.js
@@ -9,6 +9,7 @@ const handler = () => {
         counter++;
     }
     Kv.set(KEY, counter);
+    return new Response();
 }
 
 export default handler;

--- a/examples/deploy.js
+++ b/examples/deploy.js
@@ -1,10 +1,21 @@
 export default async () => {
   try {
-    let code = "export default (arg) => console.log(arg)";
+    const code = ```
+export default (request) => {
+  const arg = request.text();
+  console.log(arg);
+  return new Response();
+}
+```;
     console.log(code);
-    let contract = Ledger.createContract(code);
+    const subcontractAddress = Ledger.createContract(code);
     console.log("created", contract);
-    let response = await Contract.call(contract, 'Hello World');
 
+    await Contract.call(new Request(`tezos://${subcontractAddress}/`, { 
+      method: "POST", 
+      body: "Hello World" 
+    }));
+
+    return new Response();
   } catch (error) { console.error(error) }
 }

--- a/examples/display_request.js
+++ b/examples/display_request.js
@@ -1,7 +1,7 @@
 function handler(request) {
   try {
     console.log(`Hello from ${Ledger.selfAddress()} 👋`)
-    console.log("Method: ",request.method)
+    console.log("Method: ", request.method)
     console.log("Referer:", request.headers.get("Referer"))
     console.log("Url:", request.url)
     let url = new URL(request.url);
@@ -17,7 +17,7 @@ function handler(request) {
     console.log("Url protocol:", url.protocol);
     console.log("Url search:", url.search);
     console.log("Url username:", url.username);
-    return new Response("Success")
+    return new Response()
   } catch (error) {
     console.error(error)
     return Response.error(error)

--- a/examples/encoding.js
+++ b/examples/encoding.js
@@ -20,5 +20,5 @@ export default () => {
     console.error(`error decoding ${test_string}: ${error}`);
     throw error;
   }
-  return new Response("Success!")
+  return new Response()
 }

--- a/examples/headers.js
+++ b/examples/headers.js
@@ -67,6 +67,8 @@ const handler = () => {
         myHeaders.set("Content-Type", "text/html");
         console.log(`Actual: ${myHeaders.get("Content-Type")}, Expected: text/html`)
     }
+
+    return new Response();
 }
 
 export default handler;

--- a/examples/json_storage.js
+++ b/examples/json_storage.js
@@ -15,6 +15,7 @@ const handler = () => {
         account.nonce++;
     }
     Kv.set(key, account);
+    return new Response()
 }
 
 export default handler;

--- a/examples/ledger.js
+++ b/examples/ledger.js
@@ -16,6 +16,7 @@ const doDemo = () => {
     doTransfer(10);
     logBalance(SELF);
     logBalance(OTHER);
+    return new Response();
 }
 
 console.log("Hello JS 👋");

--- a/examples/logging.js
+++ b/examples/logging.js
@@ -5,10 +5,11 @@ function handler () {
     console.info("About to call Sam's amazing new function.");
     console.warn("Not sure if Sam actually merged his PR yet");
     samsNewFunction();
-
   } catch (error) {
     console.error(error);
   }
+
+  return new Response();
 }
 
 export default handler;

--- a/examples/promise.js
+++ b/examples/promise.js
@@ -2,11 +2,12 @@ const doPromise = async () => {
     console.log('Hello JS from Promise');
 }
 
-const handler = () => {
-    doPromise().then(res => {
+const handler = async () => {
+    await doPromise().then(res => {
         console.log('Hello from then!');
         return 42;
     });
+    return new Response();
 }
 
 export default handler;

--- a/examples/request.js
+++ b/examples/request.js
@@ -83,6 +83,7 @@ const handler = async () => {
 } catch (e) {
     console.error(e)
 }
+    return new Response();
 }
 
 export default handler;

--- a/examples/response.js
+++ b/examples/response.js
@@ -31,6 +31,8 @@ const handler = async () => {
         const resJson = await jsonResponse.json();
         console.log(`Actual: ${resJson.my}, Expected: "data"`);
     }
+
+    return new Response();
 };
 
 export default handler;

--- a/examples/url.js
+++ b/examples/url.js
@@ -22,6 +22,8 @@ const handler = () => {
         let page = addr.searchParams.get("page");
         console.log(`User: ${user}, Page: ${page}`);
     }
+
+    return new Response();
 }
 
 export default handler;


### PR DESCRIPTION
# Context
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

Currently several of our examples can no-longer be run using `jstz` since they don't 
return `Response` objects (or incorrectly use a `Request`).

# Description
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR simply addresses these issues either by:
- Returning a default response `new Response()`.
- Correctly using a `Request` object, obtaining data either by `.json()` or `.text()`. 

# Manually testing the PR
<!-- Describe how reviewers and approvers can test this PR. -->

```sh
eval `./scripts/sandbox.sh`
tz4=tz492MCfwp9V961DhNGmKzD642uhU8j6H5nB
cat examples/counter.js | jstz deploy-contract --self-address $tz4 --balance 42
counter=tz4BBRCDpBb77TjSktAgKKBmJzzoDH9eLbH2
jstz run-contract --referer $tz4 "tezos://${counter}/"    
```