### PR TITLE
Proto/Api: Ledger Refactor

### DIFF
--- a/examples/deploy.js
+++ b/examples/deploy.js
@@ -8,7 +8,7 @@ export default (request) => {
 }
 ```;
     console.log(code);
-    const subcontractAddress = Ledger.createContract(code);
+    const subcontractAddress = await Contract.create(code);
     console.log("created", contract);
     let response = await Contract.call(contract, "Hello World");
 

--- a/examples/hello_world.js
+++ b/examples/hello_world.js
@@ -17,7 +17,7 @@ const handler = async () => {
   console.log(`My address is ${Ledger.selfAddress()}`);
 
   try {
-    const newContract = Ledger.createContract(contractCode);
+    const newContract = await Contract.create(contractCode);
     console.log("created new contract with address", newContract);
     const url = `tezos://sam.tez/myEndPoint`;
     const request = new Request(url, {

--- a/examples/hello_world_requests.js
+++ b/examples/hello_world_requests.js
@@ -17,7 +17,7 @@ const handler = async () => {
   console.log(`My address is ${Ledger.selfAddress()}`);
 
   try {
-    const newContract = Ledger.createContract(contractCode);
+    const newContract = await Contract.create(contractCode);
     console.log("created new contract with address", newContract);
     const url = `tezos://${newContract}/myEndPoint`;
     const request = new Request(url, {

--- a/jstz_core/src/native.rs
+++ b/jstz_core/src/native.rs
@@ -136,9 +136,9 @@ impl<T: NativeObject> TryFrom<JsValue> for JsNativeObject<T> {
 }
 
 pub struct Accessor {
-    name: &'static str,
-    get: Option<JsFunction>,
-    set: Option<JsFunction>,
+    pub name: &'static str,
+    pub get: Option<JsFunction>,
+    pub set: Option<JsFunction>,
 }
 
 impl Accessor {

--- a/jstz_proto/src/api/contract.rs
+++ b/jstz_proto/src/api/contract.rs
@@ -1,16 +1,20 @@
 use std::ops::DerefMut;
 
 use boa_engine::{
-    object::{Object, ObjectInitializer},
+    object::{builtins::JsPromise, Object, ObjectInitializer},
     property::Attribute,
     Context, JsArgs, JsError, JsNativeError, JsResult, JsValue, NativeFunction,
 };
 use jstz_api::http::request::Request;
-use jstz_core::{host_defined, kv::Transaction, native::JsNativeObject};
+use jstz_core::{
+    host::HostRuntime, host_defined, kv::Transaction, native::JsNativeObject, runtime,
+};
 
 use crate::{
-    context::account::Address,
+    context::account::{Account, Address, Amount},
     executor::contract::{headers, Script},
+    operation::external::ContractOrigination,
+    receipt, Error, Result,
 };
 
 use boa_gc::{empty_trace, Finalize, GcRefMut, Trace};
@@ -33,6 +37,39 @@ impl Contract {
                     .with_message("Failed to convert js value into rust type `Ledger`")
                     .into()
             })
+    }
+
+    fn create(
+        &self,
+        hrt: &impl HostRuntime,
+        tx: &mut Transaction,
+        contract_code: String,
+        initial_balance: Amount,
+    ) -> Result<String> {
+        // 1. Check if the contract has sufficient balance
+        if Account::balance(hrt, tx, &self.contract_address)? < initial_balance {
+            return Err(Error::BalanceOverflow.into());
+        }
+
+        // 2. Deploy the contract
+        let contract = ContractOrigination {
+            contract_code,
+            originating_address: self.contract_address.clone(),
+            initial_balance,
+        };
+        let receipt::DeployContract { contract_address } =
+            crate::executor::deploy_contract(hrt, tx, contract)?;
+
+        // 3. Transfer the balance to the contract
+        Account::transfer(
+            hrt,
+            tx,
+            &self.contract_address,
+            &contract_address,
+            initial_balance,
+        )?;
+
+        Ok(contract_address.to_string())
     }
 
     fn call(
@@ -82,6 +119,51 @@ impl ContractApi {
 
         contract.call(tx.deref_mut(), &request, context)
     }
+
+    fn create(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
+        host_defined!(context, host_defined);
+        let mut tx = host_defined.get_mut::<Transaction>().unwrap();
+
+        let contract = Contract::from_js_value(this)?;
+        let contract_code: String = args
+            .get(0)
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("Expected at least 1 argument but 0 provided")
+            })?
+            .try_js_into(context)?;
+
+        let initial_balance = match args.get(1) {
+            None => 0,
+            Some(balance) => balance
+                .to_big_uint64(context)?
+                .iter_u64_digits()
+                .next()
+                .unwrap_or_default(),
+        };
+
+        let promise = JsPromise::new(
+            move |resolvers, context| {
+                let address = runtime::with_global_host(|rt| {
+                    contract.create(rt, &mut tx, contract_code, initial_balance as Amount)
+                })?;
+
+                resolvers.resolve.call(
+                    &JsValue::undefined(),
+                    &[address.into()],
+                    context,
+                )?;
+                Ok(JsValue::undefined())
+            },
+            context,
+        )?;
+
+        Ok(promise.into())
+    }
 }
 
 impl jstz_core::Api for ContractApi {
@@ -93,6 +175,7 @@ impl jstz_core::Api for ContractApi {
             context,
         )
         .function(NativeFunction::from_fn_ptr(Self::call), "call", 2)
+        .function(NativeFunction::from_fn_ptr(Self::create), "create", 1)
         .build();
 
         context

--- a/packages/jstz-types/index.d.ts
+++ b/packages/jstz-types/index.d.ts
@@ -12,7 +12,7 @@ declare interface URLSearchParams {
 
 declare var URLSearchParams: {
   readonly prototype: URLSearchParams;
-  new (
+  new(
     init?: [string, string][] | Record<string, string> | string,
   ): URLSearchParams;
 };
@@ -36,7 +36,7 @@ declare interface URL {
 
 declare var URL: {
   readonly prototype: URL;
-  new (url: string, base?: string): URL;
+  new(url: string, base?: string): URL;
   canParse(url: string, base?: string): boolean;
 };
 
@@ -66,7 +66,7 @@ declare interface Headers {
 
 declare var Headers: {
   readonly prototype: Headers;
-  new (init?: HeadersInit): Headers;
+  new(init?: HeadersInit): Headers;
 };
 
 declare type RequestInfo = Request | string;
@@ -85,7 +85,7 @@ declare interface Request extends Body {
 
 declare var Request: {
   readonly prototype: Request;
-  new (input: RequestInfo, init?: RequestInit): Request;
+  new(input: RequestInfo, init?: RequestInit): Request;
 };
 
 declare interface ResponseInit {
@@ -103,7 +103,7 @@ declare interface Response extends Body {
 
 declare var Response: {
   readonly prototype: Response;
-  new (body?: BodyInit | null, init?: ResponseInit): Response;
+  new(body?: BodyInit | null, init?: ResponseInit): Response;
   json(data: unknown): Response;
   error(): Response;
 };
@@ -141,14 +141,18 @@ declare interface Kv {
 
 declare var Kv: Kv;
 
+export type Mutez = number;
+
 declare interface Ledger {
-  selfAddress(): Address;
-  createContract(code: String): Promise<Address>;
+  readonly selfAddress: Address;
+  balance(address: Address): Mutez;
+  transfer(address: Address, amount: Mutez): void;
 }
 
 declare var Ledger: Ledger;
 
 declare interface Contract {
+  create(code: String): Promise<Address>;
   call(request: Request): Promise<Response>;
 }
 


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Refactor `Ledger.createContract`](https://app.asana.com/0/1205170694555856/1205622486240777/fl), [Make `Ledger.selfAddress` a property](https://app.asana.com/0/1205170694555856/1205622486240783/f)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
**Dependencies**: #37, #36, #35 

This PR contains three minor refactors:
1. Make `Ledger.selfAddress` a readonly property 
2. Move `Ledger.createContract` to `Contract.create`
3. Make `Ledger.createContract` asynchronous (permits us to interrupt the contract running, useful for later interop + scheduling features + more consistent w/ `Contract.call`). 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
eval `./scripts/sandbox.sh`
tz4="tz492MCfwp9V961DhNGmKzD642uhU8j6H5nB"
cat examples/hello_world_requests.js | jstz deploy-contract --self-address $tz4 --balance 42
contract=tz4...
jstz run-contract --referer $tz4 "tezos://${contract}/"
```

