### PR TITLE
CLI: Deprecating SetTicketer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
  "bitflags 2.4.0",
  "boa_interner",
  "boa_macros",
- "indexmap",
+ "indexmap 2.0.2",
  "num-bigint 0.4.4",
  "rustc-hash",
 ]
@@ -220,7 +220,7 @@ dependencies = [
  "dashmap",
  "fast-float",
  "icu_normalizer",
- "indexmap",
+ "indexmap 2.0.2",
  "itertools",
  "num-bigint 0.4.4",
  "num-integer",
@@ -261,7 +261,7 @@ dependencies = [
  "boa_gc",
  "boa_macros",
  "hashbrown 0.14.1",
- "indexmap",
+ "indexmap 2.0.2",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -829,6 +829,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -1065,6 +1071,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
@@ -1138,9 +1154,11 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "serde_yaml 0.8.26",
  "signal-hook",
  "tempfile",
  "tezos-smart-rollup",
+ "tezos-smart-rollup-installer-config",
  "tezos-smart-rollup-mock",
 ]
 
@@ -1263,6 +1281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1357,16 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -1843,6 +1877,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap 1.9.3",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+dependencies = [
+ "indexmap 2.0.2",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,7 +2114,7 @@ version = "0.2.1"
 source = "git+https://gitlab.com/tezos/tezos.git?branch=ajob410@sdk-ord-paths#435203b83d3fc479d300970dcae807b66f425884"
 dependencies = [
  "hex",
- "nom",
+ "nom 7.1.3",
  "num-bigint 0.3.3",
  "num-traits",
  "tezos-smart-rollup-core",
@@ -2085,6 +2144,24 @@ version = "0.2.1"
 source = "git+https://gitlab.com/tezos/tezos.git?branch=ajob410@sdk-ord-paths#435203b83d3fc479d300970dcae807b66f425884"
 dependencies = [
  "tezos-smart-rollup-core",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "tezos-smart-rollup-installer-config"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474e2996e958c4e35b63da9a146c851fcd59930a14ab0c4e4a2b5f03006b7cdf"
+dependencies = [
+ "hex",
+ "nom 6.1.2",
+ "serde",
+ "serde_yaml 0.9.25",
+ "tezos-smart-rollup-core",
+ "tezos-smart-rollup-encoding",
+ "tezos-smart-rollup-host",
  "tezos_crypto_rs",
  "tezos_data_encoding",
  "thiserror",
@@ -2158,7 +2235,7 @@ dependencies = [
  "bitvec",
  "hex",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "num-bigint 0.3.3",
  "num-traits",
  "serde",
@@ -2281,7 +2358,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.2",
  "toml_datetime",
  "winnow",
 ]
@@ -2330,6 +2407,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "url"
@@ -2563,6 +2646,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/jstz_cli/Cargo.toml
+++ b/jstz_cli/Cargo.toml
@@ -30,6 +30,8 @@ boa_engine = "0.17.0"
 rustyline = "10.0.0"
 tezos-smart-rollup = "0.2.1"
 tezos-smart-rollup-mock = "0.2.1"
+tezos-smart-rollup-installer-config = "0.2.1"
+serde_yaml = "0.8"
 
 [[bin]]
 name = "jstz"

--- a/jstz_core/src/kv/mod.rs
+++ b/jstz_core/src/kv/mod.rs
@@ -15,7 +15,7 @@ use tezos_smart_rollup_host::{
 use crate::error::Result;
 
 mod transaction;
-mod value;
+pub mod value;
 
 pub use transaction::{Entry, Transaction};
 pub use value::Value;

--- a/jstz_core/src/kv/value.rs
+++ b/jstz_core/src/kv/value.rs
@@ -11,7 +11,7 @@ fn bincode_options() -> impl bincode::Options {
         .allow_trailing_bytes()
 }
 
-pub(crate) fn serialize<T: erased_serde::Serialize + ?Sized>(value: &T) -> Vec<u8> {
+pub fn serialize<T: erased_serde::Serialize + ?Sized>(value: &T) -> Vec<u8> {
     let mut writer = Vec::new();
     let mut bincode_serializer = bincode::Serializer::new(&mut writer, bincode_options());
 

--- a/jstz_kernel/src/inbox.rs
+++ b/jstz_kernel/src/inbox.rs
@@ -20,7 +20,6 @@ pub enum InternalMessage {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ExternalMessage {
-    SetTicketer(ContractKt1Hash),
     RunContract(RunContract),
     DeployContract(ContractOrigination),
     // TODO ⚰️ Deprecate will not be part of the CLI

--- a/jstz_kernel/src/lib.rs
+++ b/jstz_kernel/src/lib.rs
@@ -15,11 +15,6 @@ pub mod inbox;
 
 const TICKETER: RefPath = RefPath::assert_from(b"/ticketer");
 
-fn store_ticketer(rt: &mut impl Runtime, kt1: &ContractKt1Hash) -> Result<()> {
-    Storage::insert(rt, &TICKETER, kt1)?;
-    Ok(())
-}
-
 fn read_ticketer(rt: &impl Runtime) -> Option<ContractKt1Hash> {
     Some(Storage::get(rt, &TICKETER).ok()??)
 }
@@ -32,7 +27,6 @@ fn handle_message(rt: &mut (impl Runtime + 'static), message: Message) -> Result
         Message::External(ExternalMessage::RunContract(run)) => {
             apply_run_contract(rt, run)
         }
-        Message::External(ExternalMessage::SetTicketer(kt1)) => store_ticketer(rt, &kt1),
         Message::External(ExternalMessage::DeployContract(contract)) => {
             apply_deploy_contract(rt, contract)
         }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->
https://app.asana.com/0/1205170694555918/1205581410505410
# Description
This PR deprecates SetTicketer external message. It creates an installer kernel using a setup-file with the KT1 address obtained after originating the rollup kernel.
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
cargo run --bin jstz -- sandbox start

<!-- Describe how reviewers and approvers can test this PR. -->
