### PR TITLE
Refactor dyn Value

### DIFF
--- a/jstz_core/src/kv/transaction.rs
+++ b/jstz_core/src/kv/transaction.rs
@@ -85,7 +85,7 @@ impl SnapshotEntry {
     where
         V: Value,
     {
-        self.value.downcast_ref().unwrap()
+        self.value.as_any().downcast_ref().unwrap()
     }
 
     fn as_mut<V>(&mut self) -> &mut V
@@ -93,7 +93,7 @@ impl SnapshotEntry {
         V: Value,
     {
         self.dirty = true;
-        self.value.downcast_mut().unwrap()
+        self.value.as_any_mut().downcast_mut().unwrap()
     }
 
     fn into_value<V>(self) -> V

--- a/jstz_core/src/kv/value.rs
+++ b/jstz_core/src/kv/value.rs
@@ -30,9 +30,19 @@ pub(crate) fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> T {
 
 /// A key-value 'value' is a value that is can be dynamically
 /// coerced (using `Any`) and serialized.
-pub trait Value: Any + Debug + erased_serde::Serialize {}
+pub trait Value: Any + Debug + erased_serde::Serialize {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
 
-impl<T> Value for T where T: Any + Debug + erased_serde::Serialize {}
+impl<T> Value for T where T: Any + Debug + erased_serde::Serialize {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 
 // Since trait downcasting isn't permitted, we implement all methods
 // from `dyn Any`.

--- a/jstz_core/src/kv/value.rs
+++ b/jstz_core/src/kv/value.rs
@@ -1,4 +1,4 @@
-use std::any::{Any, TypeId};
+use std::any::Any;
 use std::fmt::Debug;
 
 use bincode::Options;
@@ -35,50 +35,16 @@ pub trait Value: Any + Debug + erased_serde::Serialize {
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
-impl<T> Value for T where T: Any + Debug + erased_serde::Serialize {
+impl<T> Value for T
+where
+    T: Any + Debug + erased_serde::Serialize,
+{
     fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
-    }
-
-// Since trait downcasting isn't permitted, we implement all methods
-// from `dyn Any`.
-impl dyn Value {
-    pub fn is<T: Any>(&self) -> bool {
-        let t = TypeId::of::<T>();
-        let concrete = self.type_id();
-        t == concrete
-    }
-
-    pub unsafe fn downcast_ref_unchecked<T: Any>(&self) -> &T {
-        unsafe { &*(self as *const dyn Value as *const T) }
-    }
-
-    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        if self.is::<T>() {
-            unsafe { Some(self.downcast_ref_unchecked()) }
-        } else {
-            None
-        }
-    }
-
-    pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
-        if self.is::<T>() {
-            unsafe { Some(self.downcast_mut_unchecked()) }
-        } else {
-            None
-        }
-    }
-
-    pub unsafe fn downcast_mut_unchecked<T: Any>(&mut self) -> &mut T {
-        unsafe { &mut *(self as *mut dyn Value as *mut T) }
-    }
-
-    pub fn serialize(&self) -> Vec<u8> {
-        serialize(self)
     }
 }
 
@@ -99,7 +65,7 @@ impl BoxedValue {
     where
         T: Any,
     {
-        if self.is::<T>() {
+        if self.as_any().is::<T>() {
             Ok(unsafe { self.downcast_unchecked() })
         } else {
             Err(self)


### PR DESCRIPTION
# Context

`dyn Value` currently implements all the methods from `dyn Any`. We can avoid having to implement these methods and simplify the api by adding an `as_any` method that casts from `Value` to  `dyn Any`. 

# Description

add the `as_any` and `as_any_mut` methods to the `Value` trait

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR

ran the hello world example and confirmed that it works 

<!-- Describe how reviewers and approvers can test this PR. -->
