### PR TITLE
Cli: Allow data from pipes and files

### DIFF
--- a/examples/print_body.js
+++ b/examples/print_body.js
@@ -1,0 +1,6 @@
+async function handler(request) {
+  let json = await request.json();
+  console.log(`${JSON.stringify(json)}`);
+  return new Response();
+}
+export default handler;

--- a/jstz_cli/src/deploy.rs
+++ b/jstz_cli/src/deploy.rs
@@ -1,14 +1,23 @@
 use anyhow::Result;
 use serde_json::json;
 
-use crate::{config::Config, octez::OctezClient};
+use crate::{
+    config::Config,
+    octez::OctezClient,
+    utils::{from_file_or_id, piped_input},
+};
 
 pub fn exec(
     self_address: String,
-    contract_code: String,
+    contract_code: Option<String>,
     balance: u64,
     cfg: &Config,
 ) -> Result<()> {
+    // resolve contract code
+    let contract_code = contract_code
+        .map(from_file_or_id)
+        .or_else(piped_input)
+        .unwrap_or(String::default());
     // Create JSON message
     let jmsg = json!({
         "DeployContract": {

--- a/jstz_cli/src/deploy.rs
+++ b/jstz_cli/src/deploy.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use serde_json::json;
 
 use crate::{
@@ -17,7 +17,7 @@ pub fn exec(
     let contract_code = contract_code
         .map(from_file_or_id)
         .or_else(piped_input)
-        .unwrap_or(String::default());
+        .ok_or(anyhow!("No function code supplied"))?;
     // Create JSON message
     let jmsg = json!({
         "DeployContract": {

--- a/jstz_cli/src/main.rs
+++ b/jstz_cli/src/main.rs
@@ -26,12 +26,12 @@ enum Command {
         /// Address used when deploying the contract
         #[arg(short, long)]
         self_address: String,
-        /// Function code.
-        #[arg(short, long, default_value = None)]
-        function_code: Option<String>,
         /// Initial balance
         #[arg(short, long, default_value_t = 0)]
         balance: u64,
+        /// Function code.
+        #[arg(value_name = "function_code", default_value = None)]
+        function_code: Option<String>,
     },
     /// Run a smart function using a specified URL.
     Run {

--- a/jstz_cli/src/main.rs
+++ b/jstz_cli/src/main.rs
@@ -8,6 +8,7 @@ mod octez;
 mod repl;
 mod run;
 mod sandbox;
+pub(crate) mod utils;
 
 use config::Config;
 
@@ -26,10 +27,10 @@ enum Command {
         #[arg(short, long)]
         self_address: String,
         /// Function code.
-        #[arg(short, long)]
-        function_code: String,
+        #[arg(short, long, default_value = None)]
+        function_code: Option<String>,
         /// Initial balance
-        #[arg(short, long)]
+        #[arg(short, long, default_value_t = 0)]
         balance: u64,
     },
     /// Run a smart function using a specified URL.

--- a/jstz_cli/src/run.rs
+++ b/jstz_cli/src/run.rs
@@ -5,7 +5,11 @@ use http::Method;
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_kernel::inbox::{ExternalMessage, Transaction};
 
-use crate::{config::Config, octez::OctezClient};
+use crate::{
+    config::Config,
+    octez::OctezClient,
+    utils::{from_file_or_id, piped_input},
+};
 
 pub fn exec(
     cfg: &Config,
@@ -19,7 +23,7 @@ pub fn exec(
         referrer: PublicKeyHash::from_base58(&referrer).unwrap(),
         url,
         method: Method::from_str(&http_method).unwrap(),
-        body: json_data,
+        body: json_data.map(from_file_or_id).or_else(piped_input),
     });
 
     // Create JSON message

--- a/jstz_cli/src/utils.rs
+++ b/jstz_cli/src/utils.rs
@@ -1,0 +1,21 @@
+use std::fs;
+use std::io::{self, IsTerminal};
+
+pub fn from_file_or_id(data_or_file: String) -> String {
+    // try and read the file
+    fs::read_to_string(&data_or_file)
+        // file doesn't exist so assume it's raw data
+        .unwrap_or(data_or_file)
+}
+fn get_stdin() -> String {
+    let lines: Result<Vec<_>, _> = io::stdin().lines().collect();
+    lines.expect("Can't read from stdin").join("\n")
+}
+pub fn piped_input() -> Option<String> {
+    let stdin = io::stdin();
+    if !stdin.is_terminal() {
+        Some(get_stdin())
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
# Context
This pr makes it easier to deploy contracts and attach request bodies from files.


# Description
This PR changes the interface for a single argument from each of two commands
* `jstz deploy --contract-code` 
  - If the supplied argument is a file the code will be read from that file
  - if the supplied argument is not a file the code will be the argument itself
  - if the argument is not supplied the code will be read from a pipe
  - if there is no piped data an error is raised
  - This is now a positional argument
* `jstz run --data` 
  - If the supplied argument is a file the request body will be read from that file
  - if the supplied argument is not a file the request body will be the argument itself
  - if the argument is not supplied the body will be read from a pipe
  - if there is no piped data no body will be attached.

# Manually testing the PR
* direct input
    ```bash
    cargo run -- deploy --self-address $tz4 --function-code "`cat examples/print_body.js`"
    # copy contract address to clipboard
    cargo run -- run "tezos://`pbpaste`" $tz4 --data "`cat jstz_cli/sandbox.json`"
    ```
* file input
    ```bash
    cargo run -- deploy --self-address $tz4 --function-code examples/print_body.js
    # copy contract address to clipboard
    cargo run -- run "tezos://`pbpaste`" $tz4 --data jstz_cli/sandbox.json
    ```
* pipe input
    ```bash
    cat examples/print_body.js | cargo run -- deploy --self-address $tz4 
    # copy contract address to clipboard
    cat jstz_cli/sandbox.json | cargo run -- run "tezos://`pbpaste`"
    ```
