### PR TITLE
Add log trance command

### DIFF
--- a/jstz_cli/src/log.rs
+++ b/jstz_cli/src/log.rs
@@ -1,0 +1,35 @@
+use crate::config::Config;
+use anyhow::Result;
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum Command {
+    Trace {
+        // The address of the smart function to trace the log from
+        #[arg(value_name = "SMART_FUNCTION")]
+        address: String,
+        // `pretty` or `json`
+        #[arg(short, long)]
+        format: Option<String>,
+        // filter by log level
+        #[arg(short, long)]
+        level: Option<String>,
+        // filter by text match
+        #[arg(short, long)]
+        search: Option<String>,
+    },
+}
+
+pub fn exec(command: Command, _cfg: &Config) -> Result<()> {
+    match command {
+        Command::Trace {
+            address: _,
+            format: _,
+            level: _,
+            search: _,
+        } => {
+            // TODO: connect with jstz_node for logging.
+            Ok(())
+        }
+    }
+}

--- a/jstz_cli/src/main.rs
+++ b/jstz_cli/src/main.rs
@@ -5,6 +5,7 @@ mod account;
 mod bridge;
 mod config;
 mod deploy;
+mod log;
 mod octez;
 mod repl;
 mod run;
@@ -25,6 +26,9 @@ enum Command {
     /// Commands related to the account management
     #[command(subcommand)]
     Account(account::Command),
+    // Logs smart function
+    #[command(subcommand)]
+    Log(log::Command),
     /// Deploys a smart function
     Deploy {
         /// Address used when deploying the contract
@@ -65,6 +69,7 @@ fn exec(command: Command, cfg: &mut Config) -> Result<()> {
         Command::Sandbox(sandbox_command) => sandbox::exec(cfg, sandbox_command),
         Command::Bridge(bridge_command) => bridge::exec(bridge_command, cfg),
         Command::Account(account_command) => account::exec(account_command, cfg),
+        Command::Log(log_command) => log::exec(log_command, cfg),
         Command::Deploy {
             self_address,
             function_code,


### PR DESCRIPTION
# Context

Add log trance command. This command will be used to trace the log of the target smart function.
```
Usage: jstz log trace [OPTIONS] <SMART_FUNCTION>

Arguments:
  <SMART_FUNCTION>  

Options:
  -f, --format <FORMAT>  
  -l, --level <LEVEL>    
  -s, --search <SEARCH>  
  -h, --help             Print help
```
# Manually testing the PR

Ran the command and confirmed that the args get parsed properly 
```
cargo run log trace myaddress -f pretty -s sometext 
```
