### PR TITLE
Cli: Responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "jstz_proto",
  "nix 0.20.2",
  "rand 0.8.5",
+ "reqwest",
  "rustyline",
  "serde",
  "serde_json",
@@ -1666,6 +1667,7 @@ dependencies = [
  "tezos-smart-rollup-mock",
  "tezos_crypto_rs",
  "tiny-bip39",
+ "tokio",
 ]
 
 [[package]]
@@ -3293,11 +3295,24 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
+ "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/jstz_cli/Cargo.toml
+++ b/jstz_cli/Cargo.toml
@@ -37,6 +37,8 @@ sha2 = "0.9"
 rand = "0.8"
 tiny-bip39 = "1.0.0"
 bincode = "1.3.3"
+reqwest = { version = "0.11.22", features = ["json"] }
+tokio = { version = "1.33.0", features = ["full"] }
 
 [[bin]]
 name = "jstz"

--- a/jstz_cli/src/config.rs
+++ b/jstz_cli/src/config.rs
@@ -71,6 +71,8 @@ pub struct Config {
     pub octez_node_port: u16,
     /// The port of the octez RPC node
     pub octez_node_rpc_port: u16,
+    /// The port of the jstz node
+    pub jstz_node_port: u16,
     /// Sandbox config (None if sandbox is not running)
     pub sandbox: Option<SandboxConfig>,
     /// List of accounts
@@ -114,6 +116,7 @@ impl Config {
             octez_path: PathBuf::from_str(".").unwrap(),
             octez_node_port: 18731,
             octez_node_rpc_port: 18730,
+            jstz_node_port: 8933,
             sandbox: None,
             accounts: AccountConfig::default(),
         }

--- a/jstz_cli/src/jstz.rs
+++ b/jstz_cli/src/jstz.rs
@@ -1,0 +1,60 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use jstz_proto::{operation::OperationHash, receipt::Receipt};
+use tokio::time::sleep;
+
+use crate::config::Config;
+
+pub struct JstzClient {
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl JstzClient {
+    pub fn new(cfg: &Config) -> Self {
+        Self {
+            endpoint: format!("http://127.0.0.1:{}", cfg.jstz_node_port),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn get_operation_receipt(
+        &self,
+        hash: &OperationHash,
+    ) -> Result<Option<Receipt>> {
+        let response = self
+            .get(&format!(
+                "{}/operations/{}/receipt",
+                self.endpoint,
+                hash.to_string()
+            ))
+            .await?;
+
+        if response.status().is_success() {
+            let receipt = response.json::<Receipt>().await?;
+
+            Ok(Some(receipt))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn wait_for_operation_receipt(
+        &self,
+        hash: &OperationHash,
+    ) -> Result<Receipt> {
+        loop {
+            if let Some(receipt) = self.get_operation_receipt(hash).await? {
+                return Ok(receipt);
+            }
+
+            // tokio sleep
+            sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    async fn get(&self, url: &str) -> Result<reqwest::Response> {
+        Ok(self.client.get(url).send().await?)
+    }
+}

--- a/jstz_cli/src/run.rs
+++ b/jstz_cli/src/run.rs
@@ -6,11 +6,12 @@ use jstz_proto::operation::{Content, Operation, RunContract, SignedOperation};
 
 use crate::{
     config::Config,
+    jstz::JstzClient,
     octez::OctezClient,
     utils::{from_file_or_id, piped_input},
 };
 
-pub fn exec(
+pub async fn exec(
     cfg: &mut Config,
     referrer: Option<String>,
     url: String,
@@ -51,6 +52,8 @@ pub fn exec(
         op,
     );
 
+    let hash = signed_op.hash();
+
     println!(
         "Signed operation: {}",
         serde_json::to_string_pretty(&serde_json::to_value(&signed_op)?)?
@@ -63,6 +66,13 @@ pub fn exec(
         bincode::serialize(&signed_op)?,
     )?;
 
+    let receipt = JstzClient::new(cfg)
+        .wait_for_operation_receipt(&hash)
+        .await?;
+
+    println!("Receipt: {:?}", receipt);
+
     cfg.save()?;
+
     Ok(())
 }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

**Related Tasks**: [Reading response from durable storage on smart function call](https://app.asana.com/0/1205170694555856/1205647566435499/f)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
**Dependencies**: #64, #77, #66 

This PR permits CLI users to read the responses to signed operations (e.g. `run` or `deploy`)
in their terminal without tailing the `kernel.log` file. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
cargo run --bin jstz -- deploy index.js
// expected output will contain address of the smart function just deployed
addr=tz4...
cargo run --bin jstz -- run "tezos://$addr/"
// expected output will contain response from running the smart function
```