### PR TITLE
CLI Enhancements: Account management

### DIFF
--- a/jstz_cli/src/account/mod.rs
+++ b/jstz_cli/src/account/mod.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
 use bip39::{Language, Mnemonic, MnemonicType};
 use clap::Subcommand;
+use std::io;
+use std::io::Write;
 
 pub mod account;
 
@@ -16,6 +18,10 @@ fn create_account(
     alias: String,
     cfg: &mut Config,
 ) -> Result<()> {
+    if cfg.accounts().contains(&alias) {
+        return Err(anyhow!("Account already exists"));
+    }
+
     let passphrase = match passphrase {
         Some(passphrase) => passphrase,
         None => {
@@ -35,7 +41,37 @@ fn create_account(
     Ok(())
 }
 
-fn login(alias: String, cfg: &mut Config) -> Result<()> {
+fn delete_account(alias: String, cfg: &mut Config) -> Result<()> {
+    if !cfg.accounts().contains(&alias) {
+        return Err(anyhow!("Account not found"));
+    }
+
+    // Determine the confirmation message based on the login status
+    let confirmation_message = if cfg.accounts().current_alias.as_ref() == Some(&alias) {
+        "You are currently logged into this account. Are you sure you want to delete it? (y/N): "
+    } else {
+        "Are you sure you want to delete this account? (y/N): "
+    };
+
+    print!("{}", confirmation_message);
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    if !["y", "Y", "yes", "Yes"].contains(&input.trim()) {
+        println!("Account deletion aborted.");
+        return Ok(());
+    }
+
+    cfg.accounts().remove(&alias);
+    cfg.save()?;
+
+    println!("Account successfully deleted.");
+    Ok(())
+}
+
+pub fn login(alias: String, cfg: &mut Config) -> Result<()> {
     let account = cfg.accounts().get(&alias)?;
 
     println!(
@@ -49,7 +85,17 @@ fn login(alias: String, cfg: &mut Config) -> Result<()> {
     Ok(())
 }
 
-fn whoami(cfg: &Config) -> Result<()> {
+pub fn logout(cfg: &mut Config) -> Result<()> {
+    if cfg.accounts().current_alias.is_none() {
+        return Err(anyhow!("Not logged in!"));
+    }
+
+    cfg.accounts().current_alias = None;
+    cfg.save()?;
+    Ok(())
+}
+
+pub fn whoami(cfg: &mut Config) -> Result<()> {
     let alias = cfg
         .accounts
         .current_alias
@@ -66,6 +112,17 @@ fn whoami(cfg: &Config) -> Result<()> {
     Ok(())
 }
 
+fn list(cfg: &mut Config) -> Result<()> {
+    let accounts = cfg.accounts().list_all();
+
+    println!("Accounts:");
+    for (alias, account) in accounts {
+        println!("{}: {}", alias, account.address);
+    }
+
+    Ok(())
+}
+
 #[derive(Subcommand)]
 pub enum Command {
     /// Creates account
@@ -77,21 +134,20 @@ pub enum Command {
         #[arg(short, long)]
         passphrase: Option<String>,
     },
-    /// Logs in to an account
-    Login {
+    /// Deletes account
+    Delete {
         /// User alias
         #[arg(value_name = "ALIAS")]
         alias: String,
     },
-    /// Shows the current account
-    #[command(name = "whoami")]
-    WhoAmI {},
+    /// Lists all accounts
+    List {},
 }
 
 pub fn exec(command: Command, cfg: &mut Config) -> Result<()> {
     match command {
         Command::Create { alias, passphrase } => create_account(passphrase, alias, cfg),
-        Command::Login { alias } => login(alias, cfg),
-        Command::WhoAmI {} => whoami(cfg),
+        Command::Delete { alias } => delete_account(alias, cfg),
+        Command::List {} => list(cfg),
     }
 }

--- a/jstz_cli/src/config.rs
+++ b/jstz_cli/src/config.rs
@@ -25,6 +25,10 @@ pub struct AccountConfig {
 }
 
 impl AccountConfig {
+    pub fn contains(&self, alias: &str) -> bool {
+        self.accounts.contains_key(alias)
+    }
+
     pub fn upsert(&mut self, account: Account) {
         self.accounts.insert(account.alias.clone(), account);
     }
@@ -58,6 +62,17 @@ impl AccountConfig {
         let alias = self.alias_or_current(alias)?;
 
         self.get_mut(&alias)
+    }
+
+    pub fn remove(&mut self, alias: &String) -> Option<Account> {
+        if self.current_alias == Some(alias.clone()) {
+            self.current_alias = None;
+        }
+        self.accounts.remove(alias)
+    }
+
+    pub fn list_all(&self) -> Vec<(&String, &Account)> {
+        self.accounts.iter().collect()
     }
 }
 

--- a/jstz_cli/src/main.rs
+++ b/jstz_cli/src/main.rs
@@ -64,6 +64,17 @@ enum Command {
     /// Commands related to the logs.
     #[command(subcommand)]
     Logs(logs::Command),
+    /// Logs in to an account
+    Login {
+        /// User alias
+        #[arg(value_name = "ALIAS")]
+        alias: String,
+    },
+    /// Logs out of the current account
+    Logout {},
+    /// Shows the current account
+    #[command(name = "whoami")]
+    WhoAmI {},
 }
 
 async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
@@ -84,6 +95,9 @@ async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
         } => run::exec(cfg, referrer, url, http_method, json_data).await,
         Command::Repl { self_address } => repl::exec(self_address, cfg),
         Command::Logs(logs) => logs::exec(logs, cfg),
+        Command::Login { alias } => account::login(alias, cfg),
+        Command::Logout {} => account::logout(cfg),
+        Command::WhoAmI {} => account::whoami(cfg),
     }
 }
 


### PR DESCRIPTION
# Context
https://app.asana.com/0/1205170694555918/1205670949626073
https://app.asana.com/0/1205170694555918/1205670949626069
https://app.asana.com/0/1205170694555918/1205670949626067
https://app.asana.com/0/1205170694555918/1205670949626063
https://app.asana.com/0/1205170694555918/1205647566435495

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
This PR adds support for account management in the CLI. It supports login, logout, whoami, account create, account delete and account list commands. Additionally it adds support for these aliases in run/deploy commands. The current account together with the created accounts is stored in the `~/.jstz/config.json` config under "accounts". 
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
```
cargo run -- account create alan
cargo run -- account list
cargo run -- account delete alan
cargo run -- account list
cargo run -- account create alan
cargo run -- account list
cargo run -- login alan
cargo run -- whoami
cargo run -- logout
```

<!-- Describe how reviewers and approvers can test this PR. -->
