### PR TITLE
Bugfix: Fix `console.group` indentation

### DIFF
--- a/jstz_api/src/console.rs
+++ b/jstz_api/src/console.rs
@@ -39,10 +39,18 @@ impl LogMessage {
         let indent = 2 * console.groups.len();
 
         match self {
-            LogMessage::Error(msg) => rt.write_debug(&format!("[🔴] {msg:>indent$}\n")),
-            LogMessage::Warn(msg) => rt.write_debug(&format!("[🟠] {msg:>indent$}\n")),
-            LogMessage::Info(msg) => rt.write_debug(&format!("[🟢] {msg:>indent$}\n")),
-            LogMessage::Log(msg) => rt.write_debug(&format!("[🪵] {msg:>indent$}\n")),
+            LogMessage::Error(msg) => {
+                rt.write_debug(&format!("[🔴] {:indent$}{}\n", "", msg))
+            }
+            LogMessage::Warn(msg) => {
+                rt.write_debug(&format!("[🟠] {:indent$}{}\n", "", msg))
+            }
+            LogMessage::Info(msg) => {
+                rt.write_debug(&format!("[🟢] {:indent$}{}\n", "", msg))
+            }
+            LogMessage::Log(msg) => {
+                rt.write_debug(&format!("[🪵] {:indent$}{}\n", "", msg))
+            }
         }
     }
 }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

In the context of the following example:
```typescript
function pythagoreanTriples(limit = 100) {
  for (let x = 2; x <= limit; ++x) {
    console.group(`x = ${x}`);
    for (let y = 1; y < x; ++y) {
      console.group(`y = ${y}`);
      for (let z = x; z < x + y; ++z) {
        console.log(`trying z = ${z}`);
        if (x * x + y * y === z * z) {
          console.log(`Success! ${x}^2 + ${y}^2 = ${z}^2`);
          break;
        }
      }
      console.groupEnd();
    }
    console.groupEnd();
  }
}
```

Running `pythagoreanTriples(5)` prints:
```
[🪵] group: x = 2
[🪵] group: y = 1
[🪵] trying z = 2
[🪵] group: x = 3
[🪵] group: y = 1
[🪵] trying z = 3
[🪵] group: y = 2
[🪵] trying z = 3
[🪵] trying z = 4
[🪵] group: x = 4
[🪵] group: y = 1
[🪵] trying z = 4
[🪵] group: y = 2
[🪵] trying z = 4
[🪵] trying z = 5
[🪵] group: y = 3
[🪵] trying z = 4
[🪵] trying z = 5
[🪵] Success! 4^2 + 3^2 = 5^2
[🪵] group: x = 5
[🪵] group: y = 1
[🪵] trying z = 5
[🪵] group: y = 2
[🪵] trying z = 5
[🪵] trying z = 6
[🪵] group: y = 3
[🪵] trying z = 5
[🪵] trying z = 6
[🪵] trying z = 7
[🪵] group: y = 4
[🪵] trying z = 5
[🪵] trying z = 6
[🪵] trying z = 7
[🪵] trying z = 8
```

This is not the expected output.

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR fixes the indentation issue with the above output. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
cargo run --bin jstz -- repl
>> function pythagoreanTriples(limit = 100) {
  for (let x = 2; x <= limit; ++x) {
    console.group(`x = ${x}`);
    for (let y = 1; y < x; ++y) {
      console.group(`y = ${y}`);
      for (let z = x; z < x + y; ++z) {
        console.log(`trying z = ${z}`);
        if (x * x + y * y === z * z) {
          console.log(`Success! ${x}^2 + ${y}^2 = ${z}^2`);
          break;
        }
      }
      console.groupEnd();
    }
    console.groupEnd();
  }
}
>> pythagoreanTriples(5)
```