### PR TITLE
CLI Enhancements: Account abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,6 +1643,7 @@ dependencies = [
  "bs58",
  "clap",
  "daemonize",
+ "derive_more",
  "dirs",
  "fs_extra",
  "hex",
@@ -1668,6 +1669,7 @@ dependencies = [
  "tezos_crypto_rs",
  "tiny-bip39",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/jstz_cli/Cargo.toml
+++ b/jstz_cli/Cargo.toml
@@ -39,6 +39,8 @@ tiny-bip39 = "1.0.0"
 bincode = "1.3.3"
 reqwest = { version = "0.11.22", features = ["json"] }
 tokio = { version = "1.33.0", features = ["full"] }
+derive_more = "0.99.17"
+url = "2.2.2"
 
 [[bin]]
 name = "jstz"

--- a/jstz_cli/src/account/account.rs
+++ b/jstz_cli/src/account/account.rs
@@ -1,4 +1,6 @@
+use anyhow::anyhow;
 use anyhow::Result;
+use derive_more::From;
 use jstz_crypto::{
     keypair_from_passphrase, public_key::PublicKey, public_key_hash::PublicKeyHash,
     secret_key::SecretKey,
@@ -6,29 +8,78 @@ use jstz_crypto::{
 use serde::{Deserialize, Serialize};
 
 // Represents an individual account
+#[derive(Serialize, Deserialize, Debug, Clone, From)]
+pub enum Account {
+    Owned(OwnedAccount),
+    Alias(AliasAccount),
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Account {
+pub struct OwnedAccount {
     pub alias: String,
     pub address: PublicKeyHash,
     pub secret_key: SecretKey,
     pub public_key: PublicKey,
 }
 
-impl Account {
-    pub fn from_passphrase(passphrase: String, alias: String) -> Result<Self> {
+impl OwnedAccount {
+    pub fn new(passphrase: String, alias: String) -> Result<Self> {
         let (sk, pk) = keypair_from_passphrase(passphrase.as_str()).unwrap();
 
-        println!("Secret key: {}", sk.to_string());
-        println!("Public key: {}", pk.to_string());
-
         let address = PublicKeyHash::try_from(&pk)?;
-        let new_account = Account {
+        let owned_account = Self {
             alias,
             address,
             secret_key: sk,
             public_key: pk,
         };
 
-        Ok(new_account)
+        Ok(owned_account)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AliasAccount {
+    pub alias: String,
+    pub address: PublicKeyHash,
+}
+
+impl AliasAccount {
+    pub fn new(address: String, name: String) -> Result<Self> {
+        let alias_account = Self {
+            alias: name,
+            address: PublicKeyHash::from_base58(address.as_str())?,
+        };
+
+        Ok(alias_account)
+    }
+}
+
+impl Account {
+    pub fn alias(&self) -> &str {
+        match self {
+            Account::Owned(OwnedAccount { alias, .. }) => alias,
+            Account::Alias(AliasAccount { alias, .. }) => alias,
+        }
+    }
+    pub fn address(&self) -> &PublicKeyHash {
+        match self {
+            Account::Owned(OwnedAccount { address, .. }) => address,
+            Account::Alias(AliasAccount { address, .. }) => address,
+        }
+    }
+
+    pub fn as_owned_mut(&mut self) -> Result<&mut OwnedAccount> {
+        match self {
+            Account::Owned(owned_account) => Ok(owned_account),
+            Account::Alias(_) => Err(anyhow!("Account is not owned")),
+        }
+    }
+
+    pub fn as_owned(&self) -> Result<&OwnedAccount> {
+        match self {
+            Account::Owned(owned_account) => Ok(owned_account),
+            Account::Alias(_) => Err(anyhow!("Account is not owned")),
+        }
     }
 }

--- a/jstz_cli/src/config.rs
+++ b/jstz_cli/src/config.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::account::account::Account;
+use crate::account::account::{Account, AliasAccount};
 
 fn home() -> PathBuf {
     dirs::home_dir()
@@ -25,12 +25,25 @@ pub struct AccountConfig {
 }
 
 impl AccountConfig {
+    pub fn add_alias(&mut self, alias: String, address: String) -> Result<()> {
+        if self.contains(alias.as_str()) {
+            return Err(anyhow!("Account already exists"));
+        }
+
+        let account = AliasAccount::new(address.clone(), alias.clone())?;
+
+        self.upsert(account);
+
+        Ok(())
+    }
+
     pub fn contains(&self, alias: &str) -> bool {
         self.accounts.contains_key(alias)
     }
 
-    pub fn upsert(&mut self, account: Account) {
-        self.accounts.insert(account.alias.clone(), account);
+    pub fn upsert<T: Into<Account>>(&mut self, account: T) {
+        let account = account.into();
+        self.accounts.insert(account.alias().to_string(), account);
     }
 
     pub fn alias_or_current(&self, alias: Option<String>) -> Result<String> {

--- a/jstz_cli/src/deploy.rs
+++ b/jstz_cli/src/deploy.rs
@@ -1,7 +1,11 @@
 use anyhow::{anyhow, Result};
-use jstz_proto::operation::{Content, DeployContract, Operation, SignedOperation};
+use jstz_proto::{
+    operation::{Content, DeployContract, Operation, SignedOperation},
+    receipt::Content as ReceiptContent,
+};
 
 use crate::{
+    account::account::OwnedAccount,
     config::Config,
     jstz::JstzClient,
     octez::OctezClient,
@@ -12,37 +16,48 @@ pub async fn exec(
     self_address: Option<String>,
     contract_code: Option<String>,
     balance: u64,
+    name: Option<String>,
     cfg: &mut Config,
 ) -> Result<()> {
+    // Check if account already exists
+    if let Some(name) = &name {
+        if cfg.accounts.contains(name) {
+            return Err(anyhow!("Account already exists"));
+        }
+    }
+
     let jstz_client = JstzClient::new(cfg);
 
-    // resolve contract code
+    let account = cfg.accounts.account_or_current_mut(self_address)?;
+
+    let nonce = jstz_client
+        .get_nonce(account.address().clone().to_base58().as_str())
+        .await?;
+
+    // Check if account is Owned
+    let OwnedAccount {
+        address,
+        secret_key,
+        public_key,
+        ..
+    } = account.as_owned()?.clone();
+
     let contract_code = contract_code
         .map(from_file_or_id)
         .or_else(piped_input)
         .ok_or(anyhow!("No function code supplied"))?;
 
-    let account = cfg.accounts.account_or_current_mut(self_address)?;
-
-    let nonce = jstz_client
-        .get_nonce(account.address.clone().to_base58().as_str())
-        .await?;
-
-    // Create operation
+    // Create operation TODO nonce
     let op = Operation {
-        source: account.address.clone(),
-        nonce: nonce,
+        source: address,
+        nonce: nonce.clone(),
         content: Content::DeployContract(DeployContract {
             contract_code: contract_code,
             contract_credit: balance,
         }),
     };
 
-    let signed_op = SignedOperation::new(
-        account.public_key.clone(),
-        account.secret_key.sign(op.hash())?,
-        op,
-    );
+    let signed_op = SignedOperation::new(public_key, secret_key.sign(op.hash())?, op);
 
     let hash = signed_op.hash();
 
@@ -61,6 +76,19 @@ pub async fn exec(
     let receipt = jstz_client.wait_for_operation_receipt(&hash).await?;
 
     println!("Receipt: {:?}", receipt);
+
+    // Create alias
+    if let Some(name) = name {
+        cfg.accounts.add_alias(
+            name,
+            match receipt.inner {
+                Ok(ReceiptContent::DeployContract(deploy)) => {
+                    (&deploy.contract_address).to_string()
+                }
+                _ => return Err(anyhow!("Content is not of type 'DeployContract'")),
+            },
+        )?;
+    }
 
     cfg.save()?;
 

--- a/jstz_cli/src/main.rs
+++ b/jstz_cli/src/main.rs
@@ -39,6 +39,9 @@ enum Command {
         /// Function code.
         #[arg(value_name = "function_code", default_value = None)]
         function_code: Option<String>,
+        /// Name
+        #[arg(short, long, default_value = None)]
+        name: Option<String>,
     },
     /// Run a smart function using a specified URL.
     Run {
@@ -86,7 +89,8 @@ async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
             self_address,
             function_code,
             balance,
-        } => deploy::exec(self_address, function_code, balance, cfg).await,
+            name,
+        } => deploy::exec(self_address, function_code, balance, name, cfg).await,
         Command::Run {
             url,
             referrer,

--- a/jstz_cli/src/repl.rs
+++ b/jstz_cli/src/repl.rs
@@ -14,7 +14,8 @@ use tezos_smart_rollup_mock::MockHost;
 use crate::config::Config;
 
 pub fn exec(self_address: Option<String>, cfg: &Config) -> Result<()> {
-    let address = &cfg.accounts.account_or_current(self_address)?.address;
+    let account = cfg.accounts.account_or_current(self_address)?;
+    let address = account.address();
 
     let mut rt = Runtime::new().expect("Failed to create a new runtime.");
 


### PR DESCRIPTION
# Context
https://app.asana.com/0/1205770721173533/1205782954387583
https://app.asana.com/0/1205770721173533/1205770721319114
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
This PR makes several changes to the CLI commands, primarily for account abstraction:
- long version of list command `list -l`
- Account is now split into Owned and Alias enum options
- `jstz account create —function-code <CODE>` option for adding code to accounts
- Run and Deploy have --name option for using an alias instead of contract address

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
```
cargo run --bin jstz -- list
cargo run --bin jstz -- list -l
cargo run --bin jstz -- account create alan --function-code "`cat examples/counter.js`"
cargo run --bin jstz -- login alan
cargo run --bin jstz -- deploy --name counter_function
cargo run --bin jstz -- run --name counter_function
```
<!-- Describe how reviewers and approvers can test this PR. -->
