### PR TITLE
Api: Multiline logging

### DIFF
--- a/jstz_cli/src/repl.rs
+++ b/jstz_cli/src/repl.rs
@@ -105,9 +105,11 @@ fn evaluate(input: &str, rt: &mut Runtime, hrt: &mut (impl HostRuntime + 'static
             if !res.is_undefined() {
                 println!(
                     "{}",
-                    res.to_string(&mut rt.context())
-                        .unwrap()
-                        .to_std_string_escaped()
+                    if res.is_callable() {
+                        res.to_string(rt.context()).unwrap().to_std_string_escaped()
+                    } else {
+                        res.display().to_string()
+                    },
                 );
             }
             if let Err(err) =


### PR DESCRIPTION
# Description

Updates the repl and the console to print javascript objects in a readable format.

**Related issue**: [fix [Object object] ](https://app.asana.com/0/1205770721173531/1205771213624781/f)

# Manual testing

<!-- Describe how reviewers and approvers can manually test this PR. -->

```sh
nix develop
cargo run --bin jstz -- repl
>> let x = {foo: 42}
>> x
{
 foo: 42
}
>> console.log(x)
[🪵] {
[🪵]  foo: 42
[🪵] }
```


# Checklist

- [x] Changes follow the existing code style (use `make fmt-check` to check)
- [ ] Tests for changes have been added
- [ ] Internal documentation has been added (if appropriate)
- [x] Testing instructions have been added to PR
