### PR TITLE
Bugfix: Fix missing `nonce.increment()`

### DIFF
--- a/jstz_proto/src/operation.rs
+++ b/jstz_proto/src/operation.rs
@@ -39,6 +39,7 @@ impl Operation {
         let next_nonce = Account::nonce(rt, tx, &self.source)?;
 
         if self.nonce == *next_nonce {
+            next_nonce.increment();
             Ok(())
         } else {
             Err(Error::InvalidNonce)


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

Following from #76, when verifying the nonce, we do not increment it. 
This results in `InvalidNonce` errors when executing consecutive operations from a given account

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR simply introduces a 1-liner fix that increments the nonce when running `verify_nonce`. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
cargo run --bin jstz -- account create alistair
cargo run --bin jstz -- login alistair
cargo run --bin jstz -- deploy examples/hello_world.js # Expected to be Ok
cargo run --bin jstz -- deploy examples/hello_world.js # Expected to be Ok
```