### PR TITLE
Node: Initial implementation of `/logs/<sf>/stream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-lab"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e15f180c2bf7abacfda7d8d9ee4169e7f792ec8983313dc38809e902f61c79d0"
+dependencies = [
+ "actix-http",
+ "actix-router",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "actix-web-lab-derive",
+ "ahash",
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "bytestring",
+ "csv",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "http",
+ "impl-more",
+ "itertools",
+ "local-channel",
+ "mediatype",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "actix-web-lab-derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa0b287c8de4a76b691f29dbb5451e8dd5b79d777eaf87350c9b0cbfdb5e968"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,10 +351,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "async-trait"
+version = "0.1.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "autocfg"
@@ -771,6 +837,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1217,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,9 +1246,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1545,6 +1645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,16 +1827,22 @@ name = "jstz_node"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "actix-web-lab",
  "anyhow",
  "bincode",
  "clap",
  "env_logger",
+ "futures-util",
  "hex",
  "jstz_crypto",
  "jstz_proto",
+ "parking_lot",
  "reqwest",
  "serde",
  "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1873,6 +1985,12 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "mediatype"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c408dc227d302f1496c84d9dc68c00fec6f56f9228a18f3023f976f3ca7c945"
 
 [[package]]
 name = "memchr"
@@ -2706,6 +2824,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde65b75f2603066b78d6fa239b2c07b43e06ead09435f60554d3912962b4a3c"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.0.2",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,7 +3516,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/jstz_node/Cargo.toml
+++ b/jstz_node/Cargo.toml
@@ -9,16 +9,22 @@ repository.workspace = true
 
 [dependencies]
 actix-web = "4.4.0"
+actix-web-lab = "0.20.0"
 anyhow = "1.0.75"
 bincode = "1.3.3"
 clap = { version = "^4.0", features = ["derive"] }
 env_logger = "0.10.0"
+futures-util = "0.3.29"
 hex = "0.4.3"
 jstz_proto.workspace = true
 jstz_crypto.workspace = true
+parking_lot = "0.12.1"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde = { version = "1.0.183", features = ["derive"] }
 thiserror = "1.0.50"
+tokio = "1.33.0"
+tokio-stream = "0.1.14"
+tokio-util = "0.7.10"
 
 [[bin]]
 name = "jstz-node"

--- a/jstz_node/src/main.rs
+++ b/jstz_node/src/main.rs
@@ -3,7 +3,7 @@ use std::io;
 use actix_web::{middleware::Logger, web::Data, App, HttpServer, Scope};
 use clap::Parser;
 use env_logger::Env;
-use services::{logs::stream_logs, LogService};
+use services::{logs::stream_logs, LogsService};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -55,7 +55,7 @@ async fn main() -> io::Result<()> {
     let cancellation_token = CancellationToken::new();
 
     let (broadcaster, tail_file_handle) =
-        LogService::init(args.kernel_file_path, &cancellation_token);
+        LogsService::init(args.kernel_file_path, &cancellation_token);
 
     HttpServer::new(move || {
         App::new()

--- a/jstz_node/src/services/logs/broadcaster.rs
+++ b/jstz_node/src/services/logs/broadcaster.rs
@@ -1,0 +1,91 @@
+use std::{sync::Arc, time::Duration};
+
+use actix_web::rt::time::interval;
+use actix_web_lab::{
+    sse::{self, Sse},
+    util::InfallibleStream,
+};
+use futures_util::future;
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+pub struct Broadcaster {
+    clients: Mutex<Vec<mpsc::Sender<sse::Event>>>, // TODO: Use a read-write lock instead?
+}
+
+// Pings clients every 10 seconds
+const PING_INTERVAL: u64 = 10;
+
+impl Broadcaster {
+    /// Constructs new broadcaster and spawns ping loop responsible for removing stale clients.
+    pub fn create() -> Arc<Self> {
+        let this = Arc::new(Broadcaster::new());
+
+        Broadcaster::spawn_ping(Arc::clone(&this));
+
+        this
+    }
+
+    fn new() -> Self {
+        Broadcaster {
+            clients: Mutex::new(Default::default()),
+        }
+    }
+
+    /// Pings clients every `PING_INTERVAL` seconds to see if they are alive and remove them from the broadcast
+    /// list if not.
+    fn spawn_ping(this: Arc<Self>) {
+        actix_web::rt::spawn(async move {
+            let mut interval = interval(Duration::from_secs(PING_INTERVAL));
+
+            loop {
+                interval.tick().await;
+                this.remove_stale_clients().await;
+            }
+        });
+    }
+
+    /// Removes all non-responsive clients from broadcast list.
+    async fn remove_stale_clients(&self) {
+        let clients = self.clients.lock().clone();
+
+        let mut responsive_clients = Vec::new();
+
+        for client in clients {
+            if client
+                .send(sse::Event::Comment("ping".into()))
+                .await
+                .is_ok()
+            {
+                responsive_clients.push(client);
+            }
+        }
+
+        *self.clients.lock() = responsive_clients;
+    }
+
+    /// Registers client with broadcaster, returning an SSE response body.
+    pub async fn new_client(&self) -> Sse<InfallibleStream<ReceiverStream<sse::Event>>> {
+        let (tx, rx) = mpsc::channel(10);
+
+        tx.send(sse::Data::new("connected").into()).await.unwrap();
+
+        self.clients.lock().push(tx);
+
+        Sse::from_infallible_receiver(rx)
+    }
+
+    /// Broadcasts `msg` to all clients.
+    pub async fn broadcast(&self, msg: &str) {
+        let clients = self.clients.lock().clone();
+
+        let send_futures = clients
+            .iter()
+            .map(|client| client.send(sse::Data::new(msg).into()));
+
+        // try to send to all clients, ignoring failures
+        // disconnected clients will get swept up by `remove_stale_clients`
+        let _ = future::join_all(send_futures).await;
+    }
+}

--- a/jstz_node/src/services/logs/mod.rs
+++ b/jstz_node/src/services/logs/mod.rs
@@ -1,0 +1,66 @@
+use crate::tailed_file::TailedFile;
+use actix_web::{
+    get,
+    web::{Data, Path},
+    Responder,
+};
+
+use std::io::Result;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use self::broadcaster::Broadcaster;
+
+pub mod broadcaster;
+
+#[get("{address}/stream")]
+async fn stream_logs(
+    broadcaster: Data<Broadcaster>,
+    path: Path<String>,
+) -> Result<impl Responder> {
+    let _address = path.into_inner();
+
+    Ok(broadcaster.new_client().await)
+}
+
+pub struct LogService;
+
+impl LogService {
+    // Initalise the LogService by spawning a future that reads and broadcasts the file
+    pub fn init(
+        path: String,
+        cancellation_token: &CancellationToken,
+    ) -> (Arc<Broadcaster>, JoinHandle<Result<()>>) {
+        let broadcaster = Broadcaster::create();
+
+        let tail_file_handle: JoinHandle<Result<()>> = actix_web::rt::spawn(
+            Self::tail_file(path, Arc::clone(&broadcaster), cancellation_token.clone()),
+        );
+
+        (broadcaster, tail_file_handle)
+    }
+
+    async fn tail_file(
+        path: String,
+        broadcaster: Arc<Broadcaster>,
+        stop_signal: CancellationToken,
+    ) -> std::io::Result<()> {
+        let file = TailedFile::init(&path).await?;
+        let mut lines = file.lines();
+        loop {
+            tokio::select! {
+                line = lines.next_line() => {
+                    if let Ok(Some(msg)) = line {
+                        broadcaster.broadcast(&msg).await;
+                    }
+                },
+                _ = stop_signal.cancelled() => {
+                    // The stop signal has been triggered.
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/jstz_node/src/services/logs/mod.rs
+++ b/jstz_node/src/services/logs/mod.rs
@@ -24,9 +24,9 @@ async fn stream_logs(
     Ok(broadcaster.new_client().await)
 }
 
-pub struct LogService;
+pub struct LogsService;
 
-impl LogService {
+impl LogsService {
     // Initalise the LogService by spawning a future that reads and broadcasts the file
     pub fn init(
         path: String,

--- a/jstz_node/src/services/mod.rs
+++ b/jstz_node/src/services/mod.rs
@@ -5,4 +5,4 @@ mod operations;
 pub use accounts::AccountsService;
 pub use operations::OperationsService;
 
-pub use logs::LogService;
+pub use logs::LogsService;

--- a/jstz_node/src/services/mod.rs
+++ b/jstz_node/src/services/mod.rs
@@ -1,5 +1,8 @@
 mod accounts;
+pub mod logs;
 mod operations;
 
 pub use accounts::AccountsService;
 pub use operations::OperationsService;
+
+pub use logs::LogService;

--- a/jstz_node/src/tailed_file.rs
+++ b/jstz_node/src/tailed_file.rs
@@ -1,0 +1,21 @@
+use std::io::SeekFrom;
+use tokio::io::{AsyncSeekExt, BufReader, Result};
+use tokio::{fs::File, io::Lines};
+
+pub struct TailedFile(BufReader<File>);
+
+pub use tokio::io::AsyncBufReadExt;
+
+impl TailedFile {
+    pub async fn init(path: &str) -> Result<Self> {
+        let mut file = File::open(path).await?;
+        let _ = file.seek(SeekFrom::End(0));
+        let reader = BufReader::new(file);
+
+        return Ok(TailedFile(reader));
+    }
+
+    pub fn lines(self) -> Lines<BufReader<File>> {
+        self.0.lines()
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a log stream service that is responsible for reading the kernel.log file and broadcasting to the clients through SSE. 

**Related task**: [Name](https://app.asana.com/0/1205770721173533/1205770721347923)

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->
First, we can start updating the kernel log file by running:
```
cargo run --bin jstz sandbox start
```
Run the jstz node with the path to the kernel file
```
cargo run --bin jstz-node --  --kernel-file-path logs/kernel.log
```
Now clients can read the logs by
```
curl http://localhost:8933/logs/foo/stream
```
<!-- Describe your changes in detail. -->

# Manual testing

<!-- Describe how reviewers and approvers can manually test this PR. -->

```sh
npm run docs:dev
```

# Checklist

- [x] Changes follow the existing code style (use `make fmt-check` to check)
- [x] Documentation has been locally tested
- [ ] **ALL** spec deviations of the implemented methods have been documented
