### PR TITLE
Docs: Contract API

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -37,6 +37,7 @@ export default defineConfig({
           { text: "Overview", link: "/api/" },
           { text: "Console", link: "/api/console" },
           { text: "KV", link: "/api/kv" },
+          { text: "Contract", link: "/api/contract" },
           { text: "Ledger", link: "/api/ledger" },
           { text: "Headers", link: "/api/headers" },
           { text: "Request", link: "/api/request" },

--- a/docs/api/contract.md
+++ b/docs/api/contract.md
@@ -1,0 +1,53 @@
+# 📜 Contract
+
+The `Contract` namespace provides an API to create and call`jstz` smart functions.
+New smart functions can be created with the `Contract.create()` method
+and `Contract.call()` is used for calling other smart functions.
+
+All operations on `Contract` are asynchronous.
+
+## Quick Start
+
+We may deploy a new smart function programatically by calling `Contract.create()` with a single `string` argument.
+The smart function code must be valid ECMAScript. TypeScript is not supported when deploying functions using
+`Contract.create`.
+
+```typescript
+const newContract = Contract.create(
+  "export default handler () => new Response()",
+);
+```
+
+This will deploy a new smart function with the code `export default handler () => new Response()`,
+returning a _promise_ which will resolve to the address of the new function.
+
+Once a smart function is deployed we may call it from another smart function using the
+`Contract.call()` method. To call a smart function we create a new [Request](request.md) object with
+scheme `tezos` and the address as the hostname.
+
+```typescript
+async function handler(_: Request): Promise<Response> {
+  const newAddress = await Contract.create(
+    "export default handler () => new Response()",
+  );
+  return Contract.call(new Request(`tezos://${newAddress}`));
+}
+```
+
+## Instance Methods
+
+### `Contract.call(request: Request): Promise<Response>`
+
+Calls a `jstz` smart function with the given request, returning a promise that resolves to an
+HTTP [`Response`](response.md) object.
+
+- **request**: An HTTP [`Request`](request.md) object.
+  The URL scheme _must_ be `tezos` and the host _must_ be the address of a deployed `jstz` smart function.
+  The `Referer` header _must_ not be set.
+
+### `Contract.create(code : string): Promise<Address>`
+
+Creates and deploys a new `jstz` smart function with the given code, returning a promise that resolves to the address of the newly deployed smart function.
+
+- **code**: A `string` containing an ECMAscript module.
+  The module _must_ define a default export of type `(request: Request) => Response | Promise<Response>`.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -23,5 +23,5 @@ running on Tezos's smart optimistic rollups, some APIs are not available (e.g. `
 ## `jstz`-specific APIs
 
 - [`Kv`](./kv.md)
-- `Contract`
+- [`Contract`](./contract.md)
 - [`Ledger`](./ledger.md)


### PR DESCRIPTION
# Context

This PR adds documentation for the `Contract` API

# Description
Documentation is kept short as the API is likely to change in the future.
# Manually testing the PR

```bash
npm run docs:dev
```
