### PR TITLE
Nix: Fix openssl issue

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,27 +55,38 @@
               (pkgs.stdenv.isAarch64 && pkgs.stdenv.isDarwin)
               ["stackprotector"];
 
-            shellHook = ''
-              npm install
-              export PATH="$PWD/node_modules/.bin/:$PATH"
-            '';
+            shellHook = with pkgs;
+              lib.strings.concatLines
+              ([
+                  ''
+                    npm install
+                    export PATH="$PWD/node_modules/.bin/:$PATH"
+                  ''
+                ]
+                ++ lib.optionals stdenv.isLinux [
+                  ''
+                    export PKG_CONFIG_PATH=${openssl.dev}/lib/pkgconfig
+                  ''
+                ]);
 
-            buildInputs = with pkgs; [
-              llvmPackages_16.clangNoLibc
-              (rust-bin.stable."1.71.0".default.override {
-                targets = ["wasm32-unknown-unknown"];
-              })
-              rust-analyzer
-              wabt
+            buildInputs = with pkgs;
+              [
+                llvmPackages_16.clangNoLibc
+                (rust-bin.stable."1.71.0".default.override {
+                  targets = ["wasm32-unknown-unknown"];
+                })
+                rust-analyzer
+                wabt
 
-              nodejs
-              prefetch-npm-deps
+                nodejs
+                prefetch-npm-deps
 
-              alejandra
+                alejandra
 
-              python311Packages.base58
-              jq
-            ];
+                python311Packages.base58
+                jq
+              ]
+              ++ lib.optionals stdenv.isLinux [pkg-config openssl.dev];
           };
         }
       );

--- a/nix/jstz.nix
+++ b/nix/jstz.nix
@@ -23,6 +23,15 @@
     version = "0.1.0";
     src = ../.;
 
+    # Needed to get openssl-sys (required by `jstz_proto`) to use pkg-config.
+    nativeBuildInputs = with pkgs; lib.optionals stdenv.isLinux [pkg-config];
+
+    # Needed to get openssl-sys to use pkg-config.
+    # Doesn't seem to like OpenSSL 3
+    OPENSSL_NO_VENDOR = 1;
+
+    buildInputs = with pkgs; lib.optionals stdenv.isLinux [openssl openssl.dev];
+
     NIX_LDFLAGS = pkgs.lib.optional pkgs.stdenv.isDarwin (
       makeFrameworkFlags [
         "Security"


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

**Related Tasks**: [Fix openssl nixos issue](https://app.asana.com/0/1205770721173531/1205782959048378/f)

Currently running `cargo build` on a pure Linux environment (e.g. the one provided by nixos) gives the following error:
```
$ cargo run --bin jstz
   Compiling blst v0.3.10
   Compiling openssl-sys v0.9.93
error: failed to run custom build command for `openssl-sys v0.9.93`

Caused by:
  process didn't exit successfully: `/home/xavierm02/Workspace/jstz/target/debug/build/openssl-sys-a99f684bd376fccf/build-script-main` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
  OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
  OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_DIR
  OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=OPENSSL_STATIC
  cargo:rerun-if-env-changed=OPENSSL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  run pkg_config fail: `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS="1" "pkg-config" "--libs" "--cflags" "openssl"` did not exit successfully: exit status: 1
  error: could not find system library 'openssl' required by the 'openssl-sys' crate

  --- stderr
  Package openssl was not found in the pkg-config search path.
  Perhaps you should add the directory containing `openssl.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'openssl' found


  --- stderr
  thread 'main' panicked at '

  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = x86_64-unknown-linux-gnu
  openssl-sys = 0.9.93

  ', /home/xavierm02/.cargo/registry/src/index.crates.io-6f17d22bba15001f/openssl-sys-0.9.93/build/find_normal.rs:190:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR configures:
- Configures the nix shell to expose openssl, additionally it ensures openssl and pkg-config are available from the shell
- Configures the rust platform nix uses to build our crates to have pkg-config and openssl. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

@xavierm02 
```sh
nix build
```
and
```sh
nix develop
cargo build
```