### PR TITLE
Bugfix: Ensure sandbox config clears when closing sandbox

### DIFF
--- a/jstz_cli/src/octez.rs
+++ b/jstz_cli/src/octez.rs
@@ -36,6 +36,8 @@ impl OctezClient {
             &format!("http://127.0.0.1:{}", cfg.octez_node_rpc_port),
         ]);
 
+        command.env("TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER", "Y");
+
         Ok(command)
     }
 
@@ -128,9 +130,7 @@ impl OctezClient {
         Ok(())
     }
 
-    pub fn bake(cfg: &Config, log_file: &PathBuf, options: &[&str]) -> Result<String> {
-        let log_file = File::create(log_file)?;
-
+    pub fn bake(cfg: &Config, log_file: &File, options: &[&str]) -> Result<String> {
         output(
             Self::command(cfg)?
                 .arg("bake")


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->


Currently the sandbox occasionally reports:
```
...
Saving sandbox config
^CReceived signal 2, shutting down...
Error: Command "/Users/ajob410/tezos/jstz/octez-client" "-base-dir" "/var/folders/5j/sd7sw3657ld425146jzz54xr0000gn/T/nix-shell.BPq0My/octez_clientLOHfDI" "-endpoint" "http://127.0.0.1:18730" "bake" "for" "--minimal-timestamp" failed:
```
This error results in the sandbox config not being cleared, meaning when running `sandbox start` following this, 
the CLI complains that the sandbox is already running. 

This heisenbug can be forced with the following diff:
```diff
diff --git a/jstz_cli/src/sandbox/daemon.rs b/jstz_cli/src/sandbox/daemon.rs
index ddabe5b..d91173f 100644
--- a/jstz_cli/src/sandbox/daemon.rs
+++ b/jstz_cli/src/sandbox/daemon.rs
@@ -249,12 +249,12 @@ impl OctezThread {
 
         let thread_handle: JoinHandle<Result<()>> = thread::spawn(move || {
             loop {
+                f(&cfg)?;
+
                 if shutdown_rx.try_recv().is_ok() {
                     break;
                 }
 
-                f(&cfg)?;
-
                 sleep(Duration::from_secs(1));
             }
 ```

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR fixes the issue of the baker failing when shutting down due to the node shutting down.

Additionally this PR fixes some logging around `logs/client.log`, namely ensuring that the logs are retained every time the bake command is ran.

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
cargo run --bin jstz -- sandbox start
```
and then ctrl-c-ing it with the above diff applied. 

