### PR TITLE
Implement IntoJs for JsValue and JsNativeObject

### DIFF
--- a/jstz_core/src/native.rs
+++ b/jstz_core/src/native.rs
@@ -15,6 +15,8 @@ use boa_gc::{Finalize, GcRef, GcRefMut, Trace};
 
 pub use boa_engine::{object::NativeObject, NativeFunction};
 
+use crate::value::IntoJs;
+
 /// This struct permits Rust types to be passed around as JavaScript objects.
 #[derive(Trace, Finalize)]
 pub struct JsNativeObject<T: NativeObject> {
@@ -118,6 +120,19 @@ impl<T: NativeObject> JsNativeObject<T> {
         self.object()
             .downcast_mut::<T>()
             .expect("Type mismatch in `JsNativeObject`")
+    }
+}
+
+impl<T: NativeObject> Into<JsValue> for JsNativeObject<T> {
+    fn into(self) -> JsValue {
+        self.to_inner()
+    }
+}
+
+impl<T: NativeObject> IntoJs for JsNativeObject<T> {
+    #[inline]
+    fn into_js(self, context: &mut Context<'_>) -> JsValue {
+        self.into()
     }
 }
 

--- a/jstz_core/src/value.rs
+++ b/jstz_core/src/value.rs
@@ -29,6 +29,7 @@ macro_rules! impl_into_js_from_into {
 }
 
 impl_into_js_from_into!(
+    JsValue,
     JsArray,
     JsArrayBuffer,
     JsBigInt,


### PR DESCRIPTION
# Context

`JsValue` and `JsNativeObject<T>` were missing `JsInto` implementations (useful, for example, to lift `JsFunction` objects to Rust functions)

# Description

Added `JsInto` implementations for `JsValue` and `JsNativeObject<T>`

