### PR TITLE
Fix Darwin CC flags dilemma when targeting WASM and other architectures

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,23 @@
               frameworks
             );
 
+          clangNoArch =
+            if pkgs.stdenv.isDarwin
+            then
+              pkgs.clang.overrideAttrs (old: {
+                postFixup = ''
+                  ${old.postFixup or ""}
+
+                  # On macOS this contains '-march' and '-mcpu' flags. These flags
+                  # would be used for any invocation of Clang.
+                  # Removing those makes the resulting Clang wrapper usable when
+                  # cross-compiling where passing '-march' and '-mcpu' would not
+                  # make sense.
+                  echo > $out/nix-support/cc-cflags-before
+                '';
+              })
+            else pkgs.clang;
+
           jstz = pkgs.callPackage ./nix/jstz.nix {makeFrameworkFlags = makeFrameworkFlags;};
         in {
           packages = {
@@ -40,8 +57,7 @@
           };
 
           # Rust dev environment
-          devShells.default = pkgs.mkShell rec {
-            NIX_CFLAGS_COMPILE = "-mcpu=generic";
+          devShells.default = pkgs.mkShell {
             NIX_LDFLAGS = pkgs.lib.optional pkgs.stdenv.isDarwin (
               makeFrameworkFlags [
                 "Security"
@@ -50,6 +66,12 @@
             );
 
             CC = "clang";
+
+            # This tells the 'cc' Rust crate to build using this C compiler when
+            # targeting other architectures.
+            CC_wasm32_unknown_unknown = "${clangNoArch}/bin/clang";
+            CC_riscv64gc_unknown_hermit = "${clangNoArch}/bin/clang";
+
             hardeningDisable =
               pkgs.lib.optionals
               (pkgs.stdenv.isAarch64 && pkgs.stdenv.isDarwin)


### PR DESCRIPTION
Not all architectures in Clang support `-mcpu`. Therefore it is better to not use those machine-specific flags at all when cross-compiling to other architectures.