### PR TITLE
Cli: implement `jstz logs trace <sf>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "expect-test"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1297,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1793,6 +1811,7 @@ dependencies = [
  "derive_more",
  "dirs",
  "fs_extra",
+ "futures-util",
  "hex",
  "http",
  "jstz_api",
@@ -1803,6 +1822,7 @@ dependencies = [
  "nix 0.20.2",
  "rand 0.8.5",
  "reqwest",
+ "reqwest-eventsource",
  "rustyline",
  "serde",
  "serde_json",
@@ -2730,12 +2750,30 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f529a5ff327743addc322af460761dff5b50e0c826b9e6ac44c3195c50bb2026"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror",
 ]
 
 [[package]]
@@ -3859,6 +3897,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -43,6 +43,8 @@ derive_more = "0.99.17"
 url = "2.2.2"
 
 boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@create-realm-with-default-globals" }
+reqwest-eventsource = "0.5.0"
+futures-util = "0.3.29"
 
 [[bin]]
 name = "jstz"

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
+use jstz_proto::context::account::Address;
 use serde::{Deserialize, Serialize};
 
 use crate::account::account::{Account, AliasAccount};
@@ -97,6 +98,18 @@ impl AccountConfig {
 
     pub fn list_all(&self) -> Vec<(&String, &Account)> {
         self.accounts.iter().collect()
+    }
+
+    pub fn get_address(&self, address_or_alias: &str) -> Result<Address> {
+        if let Ok(address) = Address::from_base58(address_or_alias) {
+            return Ok(address);
+        }
+
+        if let Ok(account) = self.get(address_or_alias) {
+            return Ok(account.address().clone());
+        }
+
+        Err(anyhow!("Invalid alias or address"))
     }
 }
 

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -110,6 +110,8 @@ pub struct Config {
     pub octez_node_port: u16,
     /// The port of the octez RPC node
     pub octez_node_rpc_port: u16,
+    /// The host of the jstz node
+    pub jstz_node_host: String,
     /// The port of the jstz node
     pub jstz_node_port: u16,
     /// Sandbox config (None if sandbox is not running)
@@ -155,6 +157,7 @@ impl Config {
             octez_path: PathBuf::from_str(".").unwrap(),
             octez_node_port: 18731,
             octez_node_rpc_port: 18730,
+            jstz_node_host: "127.0.0.1".to_string(),
             jstz_node_port: 8933,
             sandbox: None,
             accounts: AccountConfig::default(),

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -17,7 +17,7 @@ pub struct JstzClient {
 impl JstzClient {
     pub fn new(cfg: &Config) -> Self {
         Self {
-            endpoint: format!("http://127.0.0.1:{}", cfg.jstz_node_port),
+            endpoint: format!("http://{}:{}", cfg.jstz_node_host, cfg.jstz_node_port),
             client: reqwest::Client::new(),
         }
     }

--- a/crates/jstz_cli/src/logs/mod.rs
+++ b/crates/jstz_cli/src/logs/mod.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Subcommand;
+use jstz_crypto::public_key_hash::PublicKeyHash;
 
 use crate::config::Config;
 
@@ -9,36 +10,17 @@ mod trace;
 pub enum Command {
     /// View logs
     Trace {
-        /// View console.log messages
-        #[arg(long)]
-        log: bool,
-        /// View console.info messages
-        #[arg(long)]
-        info: bool,
-        /// View console.warn messages
-        #[arg(long)]
-        warn: bool,
-        /// View console.error messages
-        #[arg(long)]
-        error: bool,
-        /// View contract creations
-        #[arg(long)]
-        contract: bool,
-        /// Add custom search strings
-        #[arg(long, value_name = "custom_strings")]
-        custom: Vec<String>,
+        #[arg(value_name = "SMART_FUNCTIOIN")]
+        address: String,
     },
 }
 
-pub fn exec(command: Command, cfg: &mut Config) -> Result<()> {
+pub async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
     match command {
-        Command::Trace {
-            log,
-            info,
-            warn,
-            error,
-            contract,
-            custom,
-        } => trace::exec(log, info, warn, error, contract, custom, cfg),
+        Command::Trace { address } => {
+            let address = PublicKeyHash::from_base58(&address)
+                .map_err(|_| anyhow!("Invalid smart function address"))?;
+            trace::exec(address, cfg).await
+        }
     }
 }

--- a/crates/jstz_cli/src/logs/mod.rs
+++ b/crates/jstz_cli/src/logs/mod.rs
@@ -1,7 +1,5 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::Subcommand;
-use jstz_crypto::public_key_hash::PublicKeyHash;
-use jstz_proto::context::account::Address;
 
 use crate::config::Config;
 
@@ -19,21 +17,6 @@ pub enum Command {
 
 pub async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
     match command {
-        Command::Trace { smart_function } => {
-            let address = get_address_for_smart_function(&smart_function, cfg)?;
-            trace::exec(address, cfg).await
-        }
+        Command::Trace { smart_function } => trace::exec(smart_function, cfg).await,
     }
-}
-
-fn get_address_for_smart_function(smart_function: &str, cfg: &Config) -> Result<Address> {
-    if let Ok(address) = PublicKeyHash::from_base58(smart_function) {
-        return Ok(address);
-    }
-
-    if let Ok(account) = cfg.accounts.get(smart_function) {
-        return Ok(account.address().clone());
-    }
-
-    Err(anyhow!("Invalid smart function alias or address"))
 }

--- a/crates/jstz_cli/src/logs/mod.rs
+++ b/crates/jstz_cli/src/logs/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use jstz_crypto::public_key_hash::PublicKeyHash;
+use jstz_proto::context::account::Address;
 
 use crate::config::Config;
 
@@ -10,17 +11,29 @@ mod trace;
 pub enum Command {
     /// View logs
     Trace {
-        #[arg(value_name = "SMART_FUNCTIOIN")]
-        address: String,
+        // The address or the alias of the smart function
+        #[arg(value_name = "ALIAS|ADDRESS")]
+        smart_function: String,
     },
 }
 
 pub async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
     match command {
-        Command::Trace { address } => {
-            let address = PublicKeyHash::from_base58(&address)
-                .map_err(|_| anyhow!("Invalid smart function address"))?;
+        Command::Trace { smart_function } => {
+            let address = get_address_for_smart_function(&smart_function, cfg)?;
             trace::exec(address, cfg).await
         }
     }
+}
+
+fn get_address_for_smart_function(smart_function: &str, cfg: &Config) -> Result<Address> {
+    if let Ok(address) = PublicKeyHash::from_base58(smart_function) {
+        return Ok(address);
+    }
+
+    if let Ok(account) = cfg.accounts.get(smart_function) {
+        return Ok(account.address().clone());
+    }
+
+    Err(anyhow!("Invalid smart function alias or address"))
 }

--- a/crates/jstz_cli/src/logs/trace.rs
+++ b/crates/jstz_cli/src/logs/trace.rs
@@ -2,10 +2,10 @@ use crate::Config;
 use anyhow::Result;
 use futures_util::stream::StreamExt;
 use jstz_api::LogRecord;
-use jstz_proto::context::account::Address;
 use reqwest_eventsource::{Event, EventSource};
 
-pub async fn exec(address: Address, cfg: &Config) -> Result<()> {
+pub async fn exec(address_or_alias: String, cfg: &Config) -> Result<()> {
+    let address = cfg.accounts.get_address(&address_or_alias)?;
     let url = format!(
         "http://{}:{}/logs/{}/stream",
         cfg.jstz_node_host,

--- a/crates/jstz_cli/src/logs/trace.rs
+++ b/crates/jstz_cli/src/logs/trace.rs
@@ -1,71 +1,33 @@
-use anyhow::Result;
-use std::process::{Command, Stdio};
-
 use crate::Config;
+use anyhow::Result;
+use futures_util::stream::StreamExt;
+use jstz_api::LogRecord;
+use jstz_proto::context::account::Address;
+use reqwest_eventsource::{Event, EventSource};
 
-const ERROR: &str = "🔴";
-const WARN: &str = "🟠";
-const INFO: &str = "🟢";
-const LOG: &str = "🪵";
-const CONTRACT: &str = "📜";
+pub async fn exec(address: Address, cfg: &Config) -> Result<()> {
+    let url = format!(
+        "http://{}:{}/logs/{}/stream",
+        cfg.jstz_node_host,
+        cfg.jstz_node_port,
+        &address.to_base58()
+    );
 
-pub fn exec(
-    log: bool,
-    info: bool,
-    warn: bool,
-    error: bool,
-    contract: bool,
-    custom: Vec<String>,
-    cfg: &Config,
-) -> Result<()> {
-    let logs_dir = cfg.jstz_path.join("logs");
-    let log_path = logs_dir.join("kernel.log");
+    let mut event_source = EventSource::get(&url);
 
-    let mut grep_for = Vec::new();
-    if log {
-        grep_for.push(LOG.to_string());
-    }
-    if info {
-        grep_for.push(INFO.to_string());
-    }
-    if warn {
-        grep_for.push(WARN.to_string());
-    }
-    if error {
-        grep_for.push(ERROR.to_string());
-    }
-    if contract {
-        grep_for.push(CONTRACT.to_string());
-    }
-    for s in &custom {
-        grep_for.push(s.clone());
-    }
-
-    if grep_for.is_empty() {
-        grep_for.extend(
-            [LOG, INFO, WARN, ERROR, CONTRACT]
-                .iter()
-                .map(|&s| s.to_string()),
-        );
-    }
-
-    let grep_pattern = grep_for.join("\\|");
-
-    let tail = Command::new("tail")
-        .arg("-f")
-        .arg(log_path.clone())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("Failed to start tail command");
-
-    if let Some(tail_stdout) = tail.stdout {
-        Command::new("grep")
-            .arg(grep_pattern)
-            .stdin(tail_stdout)
-            .spawn()
-            .expect("Failed to start grep command")
-            .wait()
-            .expect("Failed to wait for grep command");
+    while let Some(event) = event_source.next().await {
+        match event {
+            Ok(Event::Open) => println!("Connection open with {}", url),
+            Ok(Event::Message(message)) => {
+                if let Ok(log_record) = serde_json::from_str::<LogRecord>(&message.data) {
+                    println!("{}", serde_json::to_string_pretty(&log_record).unwrap());
+                }
+            }
+            Err(err) => {
+                println!("Event source error: {}", err);
+                event_source.close();
+            }
+        }
     }
 
     Ok(())

--- a/crates/jstz_cli/src/main.rs
+++ b/crates/jstz_cli/src/main.rs
@@ -103,7 +103,7 @@ async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
             json_data,
         } => run::exec(cfg, referrer, url, http_method, json_data).await,
         Command::Repl { self_address } => repl::exec(self_address, cfg),
-        Command::Logs(logs) => logs::exec(logs, cfg),
+        Command::Logs(logs) => logs::exec(logs, cfg).await,
         Command::Login { alias } => account::login(alias, cfg),
         Command::Logout {} => account::logout(cfg),
         Command::WhoAmI {} => account::whoami(cfg),


### PR DESCRIPTION
# Context
This PR Implements `jstz logs trace <sf>`, allowing users to listen to logs from a given sf on cli
Additionally, i've added an extra field in the cli config that specifies the host of jstz node. The default should be localhost (e.g.
```
  {
   ...
  "jstz_node_host": "127.0.0.1",
  "jstz_node_port": 8933,
 ```

<!-- Why is this change required? What problem does it solve? -->

[Task link](https://app.asana.com/0/1205770721173533/1205770721347936)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR

Deploy a function,
run `jstz logs trace <sf>` to connect to the jstz node and run the function

https://github.com/trilitech/jstz/assets/128799322/9d162569-d85f-4d50-bda0-aff45ec46101

