### PR TITLE
fix(cli): fix paths in sandbox

### DIFF
--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -37,7 +37,7 @@ fn init_node(cfg: &Config) -> Result<()> {
 
 fn start_node(cfg: &Config) -> Result<Child> {
     // Run the octez-node in sandbox mode
-    let sandbox_file = cfg.jstz_path.join("jstz_cli/sandbox.json");
+    let sandbox_file = cfg.jstz_path.join("crates/jstz_cli/sandbox.json");
 
     OctezNode::run(
         cfg,
@@ -97,7 +97,7 @@ fn init_client(cfg: &Config) -> Result<()> {
     println!(" done");
 
     // 4. Activate alpha
-    let sandbox_params_file = cfg.jstz_path.join("jstz_cli/sandbox-params.json");
+    let sandbox_params_file = cfg.jstz_path.join("crates/jstz_cli/sandbox-params.json");
 
     print!("Activating alpha...");
     OctezClient::activate_protocol(


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

Currently running `sandbox start` gets stuck on:
```
Configuring sandbox... done
Initializing octez-node configuration... done
Generating identity... done
Starting node... done
```

This is because the paths for the sandbox parameter files changed.

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR simply fixes the paths to the parameter files (and any other broken paths)


# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
cargo run --bin jstz -- sandbox start
```
