### PR TITLE
Health: Add `clippy` linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v5
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Rust setup
+        run: rustup show active-toolchain
+
+      - name: Lint with Clippy
+        run: make lint
   fmt:
     name: Format
     runs-on: ubuntu-latest
@@ -35,7 +45,7 @@ jobs:
   build:
     name: Build (Cargo)
     runs-on: ubuntu-latest
-    needs: fmt
+    needs: [lint, fmt]
     steps:
       - uses: actions/checkout@v4
 
@@ -50,7 +60,7 @@ jobs:
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest
-    needs: fmt
+    needs: [lint, fmt]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -78,7 +88,7 @@ jobs:
   build-sdk:
     name: Build TypeScript SDK
     runs-on: ubuntu-latest
-    needs: fmt
+    needs: [lint, fmt]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,4 @@ fmt-check: fmt-nix-check fmt-rust-check fmt-js-check
 
 .PHONY: lint
 lint:
-	@cargo clippy -- -D warnings -A clippy::let_underscore_future -A clippy::module_inception -A clippy::op_ref -A clippy::manual_strip -A clippy::missing_safety_doc -A clippy::slow_vector_initialization -A clippy::empty_loop
+	@cargo clippy -- -D warnings -A clippy::let_underscore_future -A clippy::module_inception -A clippy::op_ref -A clippy::manual_strip -A clippy::missing_safety_doc -A clippy::slow_vector_initialization -A clippy::empty_loop -A clippy::expect-fun-call

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,7 @@ test:
 	@cargo test
 
 .PHONY: check
-check:
-	@cargo fmt --check
-	@cargo clippy --all-targets -- --deny warnings
+check: lint fmt
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,4 @@ fmt-check: fmt-nix-check fmt-rust-check fmt-js-check
 
 .PHONY: lint
 lint:
-	@cargo clippy -- -D warnings -A clippy::let_underscore_future -A clippy::module_inception -A clippy::op_ref -A clippy::manual_strip -A clippy::missing_safety_doc -A clippy::slow_vector_initialization -A clippy::empty_loop -A clippy::expect-fun-call
+	@cargo clippy -- -D warnings -A clippy::let_underscore_future -A clippy::module_inception -A clippy::op_ref -A clippy::manual_strip -A clippy::missing_safety_doc -A clippy::slow_vector_initialization -A clippy::empty_loop -A clippy::expect-fun-call -A clippy::wrong-self-convention

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,7 @@ fmt: fmt-nix fmt-rust fmt-js
 
 .PHONY: fmt-check
 fmt-check: fmt-nix-check fmt-rust-check fmt-js-check
+
+.PHONY: lint
+lint:
+	@cargo clippy -- -D warnings -A clippy::let_underscore_future -A clippy::module_inception -A clippy::op_ref -A clippy::manual_strip -A clippy::missing_safety_doc -A clippy::slow_vector_initialization -A clippy::empty_loop

--- a/crates/jstz_api/src/console.rs
+++ b/crates/jstz_api/src/console.rs
@@ -26,7 +26,7 @@ use boa_gc::{empty_trace, Finalize, GcRefMut, Trace};
 use jstz_core::{host::HostRuntime, runtime, value::IntoJs};
 use jstz_crypto::{hash::Blake2b, public_key_hash::PublicKeyHash};
 use serde::{Deserialize, Serialize};
-use serde_json;
+
 use tezos_smart_rollup::prelude::debug_msg;
 
 pub const LOG_PREFIX: &str = "[JSTZ:SMART_FUNCTION:LOG] ";
@@ -45,7 +45,7 @@ impl LogRecord {
     }
 
     pub fn from_string(json: &str) -> Self {
-        serde_json::from_str(&json).expect("Failed to deserialize JSONLog")
+        serde_json::from_str(json).expect("Failed to deserialize JSONLog")
     }
 }
 
@@ -424,7 +424,7 @@ pub enum ConsoleApi {
 }
 
 impl Console {
-    fn from_js_value<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn from_js_value(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -470,7 +470,7 @@ impl ConsoleApi {
         let console = Console::from_js_value(this)?;
         runtime::with_global_host(|rt| {
             let assertion = args.get_or_undefined(0).to_boolean();
-            let data = if args.len() >= 1 { &args[1..] } else { &[] };
+            let data = if !args.is_empty() { &args[1..] } else { &[] };
             console.assert(assertion, data, rt.deref(), context)?;
 
             Ok(JsValue::undefined())

--- a/crates/jstz_api/src/console.rs
+++ b/crates/jstz_api/src/console.rs
@@ -13,7 +13,7 @@
 //!
 //! The implementation is heavily inspired by https://github.com/boa-dev/boa/blob/main/boa_runtime/src/console/mod.rs
 
-use std::ops::Deref;
+use std::{fmt::Display, ops::Deref};
 
 use boa_engine::{
     js_string,
@@ -39,11 +39,15 @@ pub struct LogRecord {
     pub text: String,
 }
 
-impl LogRecord {
-    fn to_string(&self) -> String {
-        serde_json::to_string(&self).expect("Failed to serialize JSONLog")
+impl Display for LogRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            &serde_json::to_string(self).expect("Failed to convert LogRecord to string"),
+        )
     }
+}
 
+impl LogRecord {
     pub fn from_string(json: &str) -> Self {
         serde_json::from_str(json).expect("Failed to deserialize JSONLog")
     }
@@ -510,15 +514,15 @@ impl ConsoleApi {
         Ok(JsValue::undefined())
     }
 
-    fn to_console(self) -> Console {
+    fn to_console(&self) -> Console {
         match self {
             ConsoleApi::Proto {
                 contract_address,
                 operation_hash,
             } => Console::Proto {
                 groups: Vec::default(),
-                contract_address,
-                operation_hash,
+                contract_address: contract_address.clone(),
+                operation_hash: operation_hash.clone(),
             },
             ConsoleApi::Cli => Console::Cli {
                 groups: Vec::default(),

--- a/crates/jstz_api/src/encoding/global.rs
+++ b/crates/jstz_api/src/encoding/global.rs
@@ -16,14 +16,14 @@ impl Global {
             JsNativeError::eval().with_message(err.to_string()).into()
         }
         let str = data.to_std_string_escaped();
-        let encoded = DEFAULT_ENGINE.decode(&str).map_err(on_err)?;
+        let encoded = DEFAULT_ENGINE.decode(str).map_err(on_err)?;
         let encoded_str = core::str::from_utf8(encoded.as_slice()).map_err(on_err)?;
 
         Ok(encoded_str.into())
     }
     fn btoa(data: &JsString) -> JsResult<JsString> {
         let str = data.to_std_string_escaped();
-        let encoded = DEFAULT_ENGINE.encode(&str);
+        let encoded = DEFAULT_ENGINE.encode(str);
         Ok(encoded.into())
     }
 }
@@ -37,7 +37,7 @@ impl GlobalApi {
             .ok_or_else(|| JsNativeError::typ().with_message("expected string"))?;
         // TODO: https://github.com/trilitech/jstz/pull/197#discussion_r1413836707
         // let data: JsString = args.get_or_undefined(0).try_js_into(context);
-        let result = Global::atob(&data)?;
+        let result = Global::atob(data)?;
         Ok(result.into())
     }
     fn btoa(_: &JsValue, args: &[JsValue], _context: &mut Context) -> JsResult<JsValue> {
@@ -46,7 +46,7 @@ impl GlobalApi {
             .as_string()
             .ok_or_else(|| JsNativeError::typ().with_message("expected string"))?;
         // TODO: https://github.com/trilitech/jstz/pull/197#discussion_r1413836707
-        let result = Global::btoa(&data)?;
+        let result = Global::btoa(data)?;
         Ok(result.into())
     }
 }

--- a/crates/jstz_api/src/encoding/text_decoder.rs
+++ b/crates/jstz_api/src/encoding/text_decoder.rs
@@ -102,7 +102,7 @@ impl TryFromJs for TextDecodeOptions {
 }
 
 impl TextDecoder {
-    fn try_from_js<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -131,7 +131,7 @@ impl TextDecoder {
 
         Ok(TextDecoder {
             //  3. Set this's encoding to encoding.
-            encoding: encoding,
+            encoding,
             //  4. If options["fatal"] is true, then set this's error mode to "fatal".
             error_mode: if options.fatal {
                 "fatal".to_string()
@@ -164,7 +164,7 @@ impl TextDecoder {
     }
 
     //  https://encoding.spec.whatwg.org/#concept-td-serialize
-    fn serialize(&mut self, read: usize) -> () {
+    fn serialize(&mut self, read: usize) {
         //  1. Let output be the empty string.
         //  2. While true:
         //    1. Let item be the result of reading from ioQueue.

--- a/crates/jstz_api/src/encoding/text_encoder.rs
+++ b/crates/jstz_api/src/encoding/text_encoder.rs
@@ -49,7 +49,7 @@ pub struct TextEncoderEncodeIntoResult {
 }
 
 impl TextEncoderEncodeIntoResult {
-    fn try_from_js<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
           .as_object()
           .and_then(|obj| obj.downcast_mut::<Self>())
@@ -105,7 +105,7 @@ impl NativeClass for TextEncoderEncodeIntoResult {
 }
 
 impl TextEncoder {
-    fn try_from_js<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -124,7 +124,7 @@ impl TextEncoder {
 
     fn encode(input: Option<&[u16]>) -> JsResult<Vec<u8>> {
         //  handle optional argument
-        let input = input.unwrap_or_else(|| &[]);
+        let input = input.unwrap_or(&[]);
         //  1. Convert input to an I/O queue of scalar values.
 
         //  2. Let output be the I/O queue of bytes << end-of-queue >>.

--- a/crates/jstz_api/src/http/body.rs
+++ b/crates/jstz_api/src/http/body.rs
@@ -28,8 +28,8 @@ enum Inner {
     Bytes(Vec<u8>),
 }
 
-fn bytes_to_string(bytes: &Vec<u8>) -> JsResult<String> {
-    String::from_utf8(bytes.clone()).map_err(|_| {
+fn bytes_to_string(bytes: &[u8]) -> JsResult<String> {
+    String::from_utf8(bytes.into()).map_err(|_| {
         JsError::from_native(
             JsNativeError::typ().with_message("Failed to convert bytes into utf8 text"),
         )

--- a/crates/jstz_api/src/http/request.rs
+++ b/crates/jstz_api/src/http/request.rs
@@ -84,10 +84,9 @@ fn clone_inner_request<T: Clone>(request: &InnerRequest<T>) -> InnerRequest<T> {
         *h = headers;
     }
 
-    let request = request
-        .body(body)
-        .expect("Cannot construct a malformed request from a valid one");
     request
+        .body(body)
+        .expect("Cannot construct a malformed request from a valid one")
 }
 
 impl Clone for Request {
@@ -299,7 +298,7 @@ impl Request {
 pub struct RequestClass;
 
 impl Request {
-    fn try_from_js<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())

--- a/crates/jstz_api/src/http/response.rs
+++ b/crates/jstz_api/src/http/response.rs
@@ -341,7 +341,7 @@ impl ResponseBuilder {
 pub struct ResponseClass;
 
 impl Response {
-    pub fn try_from_js<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    pub fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())

--- a/crates/jstz_api/src/kv.rs
+++ b/crates/jstz_api/src/kv.rs
@@ -22,9 +22,9 @@ const KV_PATH: RefPath = RefPath::assert_from(b"/jstz_kv");
 #[serde(try_from = "String", into = "String")]
 pub struct KvValue(pub serde_json::Value);
 
-impl Into<String> for KvValue {
-    fn into(self) -> String {
-        self.0.to_string()
+impl From<KvValue> for String {
+    fn from(val: KvValue) -> Self {
+        val.0.to_string()
     }
 }
 

--- a/crates/jstz_api/src/random.rs
+++ b/crates/jstz_api/src/random.rs
@@ -15,7 +15,7 @@ struct RandomGen {
 }
 
 impl RandomGen {
-    fn from_js_value<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn from_js_value(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())

--- a/crates/jstz_api/src/url/mod.rs
+++ b/crates/jstz_api/src/url/mod.rs
@@ -150,7 +150,7 @@ impl Url {
         self.url = parsed_url;
 
         // 6. If `query` is non-null (not empty)
-        if query.len() > 0 {
+        if !query.is_empty() {
             // 4. Empty `self`'s query object's list
             // 6. (cont.) then set `self`’s query object’s list to `query`
             self.search_params.deref_mut().set_values(query)
@@ -302,7 +302,7 @@ impl Url {
 pub struct UrlClass;
 
 impl Url {
-    fn try_from_js<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())

--- a/crates/jstz_api/src/urlpattern.rs
+++ b/crates/jstz_api/src/urlpattern.rs
@@ -181,7 +181,7 @@ impl UrlPattern {
 pub struct UrlPatternClass;
 
 impl UrlPattern {
-    fn try_from_js<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())

--- a/crates/jstz_api/tests/wpt.rs
+++ b/crates/jstz_api/tests/wpt.rs
@@ -214,15 +214,15 @@ impl jstz_core::Api for TestHarnessReportApi {
             let value = context
                 .global_object()
                 .get(js_string!(name), context)
-                .expect(&format!("globalThis.{} is undefined", name));
+                .unwrap_or_else(|_| panic!("globalThis.{} is undefined", name));
 
             let function = value
                 .as_callable()
-                .expect(&format!("globalThis.{} is not callable", name));
+                .unwrap_or_else(|| panic!("globalThis.{} is not callable", name));
 
             function
                 .call(&JsValue::undefined(), args, context)
-                .expect(&format!("Failed to call globalThis.{}", name));
+                .unwrap_or_else(|_| panic!("Failed to call globalThis.{}", name));
         }
 
         call_global_function(
@@ -273,7 +273,7 @@ pub fn run_wpt_test_harness(bundle: &Bundle) -> JsResult<Box<TestHarnessReport>>
     for item in &bundle.items {
         match item {
             BundleItem::TestHarnessReport => {
-                TestHarnessReportApi.init(&mut rt.context());
+                TestHarnessReportApi.init(rt.context());
             }
             BundleItem::Inline(script) | BundleItem::Resource(_, script) => {
                 rt.context().eval(Source::from_bytes(script))?;

--- a/crates/jstz_api/tests/wpt.rs
+++ b/crates/jstz_api/tests/wpt.rs
@@ -214,15 +214,15 @@ impl jstz_core::Api for TestHarnessReportApi {
             let value = context
                 .global_object()
                 .get(js_string!(name), context)
-                .unwrap_or_else(|_| panic!("globalThis.{} is undefined", name));
+                .expect(&format!("globalThis.{} is undefined", name));
 
             let function = value
                 .as_callable()
-                .unwrap_or_else(|| panic!("globalThis.{} is not callable", name));
+                .expect(&format!("globalThis.{} is not callable", name));
 
             function
                 .call(&JsValue::undefined(), args, context)
-                .unwrap_or_else(|_| panic!("Failed to call globalThis.{}", name));
+                .expect(&format!("Failed to call globalThis.{}", name));
         }
 
         call_global_function(

--- a/crates/jstz_cli/src/account/mod.rs
+++ b/crates/jstz_cli/src/account/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 
 fn generate_passphrase() -> String {
     let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
-    return mnemonic.to_string();
+    mnemonic.to_string()
 }
 
 fn alias(address: String, name: String, cfg: &mut Config) -> Result<()> {

--- a/crates/jstz_cli/src/bridge/deposit.rs
+++ b/crates/jstz_cli/src/bridge/deposit.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use bs58;
 
 use crate::{config::Config, octez::OctezClient};
 

--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -50,9 +50,9 @@ pub async fn exec(
     // Create operation TODO nonce
     let op = Operation {
         source: address,
-        nonce: nonce.clone(),
+        nonce,
         content: Content::DeployContract(DeployContract {
-            contract_code: contract_code,
+            contract_code,
             contract_credit: balance,
         }),
     };
@@ -83,7 +83,7 @@ pub async fn exec(
             name,
             match receipt.inner {
                 Ok(ReceiptContent::DeployContract(deploy)) => {
-                    (&deploy.contract_address).to_string()
+                    deploy.contract_address.to_string()
                 }
                 _ => return Err(anyhow!("Content is not of type 'DeployContract'")),
             },

--- a/crates/jstz_cli/src/kv.rs
+++ b/crates/jstz_cli/src/kv.rs
@@ -30,7 +30,7 @@ async fn list(
 
     let address = cfg.accounts.get_address_from(alias)?;
 
-    let value = jstz_client.get_subkey_list(&address.as_str(), &key).await?;
+    let value = jstz_client.get_subkey_list(address.as_str(), &key).await?;
 
     // Print list of values
     match value {

--- a/crates/jstz_cli/src/main.rs
+++ b/crates/jstz_cli/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::Parser;
-use tokio;
 
 mod account;
 mod bridge;

--- a/crates/jstz_cli/src/octez.rs
+++ b/crates/jstz_cli/src/octez.rs
@@ -29,7 +29,7 @@ impl OctezClient {
         let octez_client_dir = &cfg.sandbox()?.octez_client_dir;
 
         let mut command = Command::new(cfg.octez_path.join("octez-client"));
-        command.args(&[
+        command.args([
             "-base-dir",
             octez_client_dir.to_str().expect("Invalid path"),
             "-endpoint",
@@ -48,7 +48,7 @@ impl OctezClient {
         script: &str,
         storage: &str,
     ) -> Result<String> {
-        let output = output(Self::command(cfg)?.args(&[
+        let output = output(Self::command(cfg)?.args([
             "originate",
             "contract",
             name,
@@ -69,8 +69,7 @@ impl OctezClient {
         // TODO: Replace with KT1 regex
         let address = output
             .lines()
-            .filter(|line| line.contains("New contract"))
-            .next()
+            .find(|line| line.contains("New contract"))
             .unwrap()
             .split_whitespace()
             .nth(2)
@@ -87,7 +86,7 @@ impl OctezClient {
         entrypoint: &str,
         parameter: &str,
     ) -> Result<()> {
-        output(Self::command(cfg)?.args(&[
+        output(Self::command(cfg)?.args([
             "transfer",
             "0",
             "from",
@@ -109,7 +108,7 @@ impl OctezClient {
         source: &str,
         message: T,
     ) -> Result<()> {
-        output(Self::command(cfg)?.args(&[
+        output(Self::command(cfg)?.args([
             "send",
             "smart",
             "rollup",
@@ -141,7 +140,7 @@ impl OctezClient {
     }
 
     pub fn import_secret_key(cfg: &Config, name: &str, sk: &str) -> Result<()> {
-        output(Self::command(cfg)?.args(&["import", "secret", "key", name, sk]))?;
+        output(Self::command(cfg)?.args(["import", "secret", "key", name, sk]))?;
         Ok(())
     }
 
@@ -152,7 +151,7 @@ impl OctezClient {
         key: &str,
         parameters_file: &str,
     ) -> Result<()> {
-        output(Self::command(cfg)?.args(&[
+        output(Self::command(cfg)?.args([
             "-block",
             "genesis",
             "activate",
@@ -179,7 +178,7 @@ impl OctezClient {
         r#type: &str,
         kernel: &str,
     ) -> Result<String> {
-        let output = output(Self::command(cfg)?.args(&[
+        let output = output(Self::command(cfg)?.args([
             "originate",
             "smart",
             "rollup",
@@ -223,7 +222,7 @@ impl OctezNode {
 
     pub fn config_init(cfg: &Config, network: &str, connections: &str) -> Result<()> {
         output(
-            Self::command(cfg).args(&[
+            Self::command(cfg).args([
                 "config",
                 "init",
                 "--network",
@@ -246,7 +245,7 @@ impl OctezNode {
 
     pub fn generate_identity(cfg: &Config) -> Result<()> {
         output(
-            Self::command(cfg).args(&[
+            Self::command(cfg).args([
                 "identity",
                 "generate",
                 "--data-dir",
@@ -263,7 +262,7 @@ impl OctezNode {
         let log_file = File::create(log_file)?;
 
         Ok(Self::command(cfg)
-            .args(&[
+            .args([
                 "run",
                 "--data-dir",
                 cfg.sandbox()?
@@ -285,7 +284,7 @@ impl OctezRollupNode {
         let octez_client_dir = &cfg.sandbox()?.octez_client_dir;
 
         let mut command = Command::new(cfg.octez_path.join("octez-smart-rollup-node"));
-        command.args(&[
+        command.args([
             "-base-dir",
             octez_client_dir.to_str().expect("Invalid path"),
             "-endpoint",
@@ -307,7 +306,7 @@ impl OctezRollupNode {
         Ok(Self::command(cfg)?
             .stdout(Stdio::from(log_file.try_clone()?))
             .stderr(Stdio::from(log_file.try_clone()?))
-            .args(&[
+            .args([
                 "run",
                 "operator",
                 "for",

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -27,7 +27,7 @@ pub async fn exec(
         Url::parse(&url).map_err(|e| anyhow!("Failed to parse URL: {}", e))?;
     if let Some(host) = url_object.host_str() {
         if !host.starts_with("tz4") {
-            if cfg.accounts().contains(&host) {
+            if cfg.accounts().contains(host) {
                 url_object
                     .set_host(Some(
                         cfg.accounts().get(host)?.address().to_base58().as_str(),
@@ -74,7 +74,7 @@ pub async fn exec(
 
     let op = Operation {
         source: address.clone(),
-        nonce: nonce.clone(),
+        nonce,
         content: Content::RunContract(RunContract {
             uri: url,
             method,

--- a/crates/jstz_core/src/iterators.rs
+++ b/crates/jstz_core/src/iterators.rs
@@ -125,7 +125,7 @@ pub struct PairValue {
 
 impl IntoJs for PairValue {
     fn into_js(self, context: &mut Context<'_>) -> JsValue {
-        JsArray::from_iter([self.key, self.value].into_iter(), context).into()
+        JsArray::from_iter([self.key, self.value], context).into()
     }
 }
 

--- a/crates/jstz_core/src/kv/mod.rs
+++ b/crates/jstz_core/src/kv/mod.rs
@@ -89,6 +89,7 @@ impl Storage {
     }
 }
 
+#[derive(Default)]
 pub struct Kv {
     clock: Clock,
     update_sets: [BTreeSet<OwnedPath>; MAX_TX_COUNT],
@@ -104,10 +105,7 @@ impl Kv {
     /// Create an in-memory representation of the persistent key-value store
     /// with a given _scheme_.
     pub fn new() -> Self {
-        Self {
-            clock: Clock::default(),
-            update_sets: Default::default(),
-        }
+        Self::default()
     }
 
     /// Begin a new transaction.

--- a/crates/jstz_core/src/native.rs
+++ b/crates/jstz_core/src/native.rs
@@ -28,7 +28,7 @@ impl<T: NativeObject> Clone for JsNativeObject<T> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            _phantom: self._phantom.clone(),
+            _phantom: self._phantom,
         }
     }
 }
@@ -125,15 +125,15 @@ impl<T: NativeObject> JsNativeObject<T> {
     }
 }
 
-impl<T: NativeObject> Into<JsValue> for JsNativeObject<T> {
-    fn into(self) -> JsValue {
-        self.to_inner()
+impl<T: NativeObject> From<JsNativeObject<T>> for JsValue {
+    fn from(val: JsNativeObject<T>) -> Self {
+        val.to_inner()
     }
 }
 
 impl<T: NativeObject> IntoJs for JsNativeObject<T> {
     #[inline]
-    fn into_js(self, context: &mut Context<'_>) -> JsValue {
+    fn into_js(self, _context: &mut Context<'_>) -> JsValue {
         self.into()
     }
 }

--- a/crates/jstz_core/src/realm.rs
+++ b/crates/jstz_core/src/realm.rs
@@ -301,9 +301,10 @@ impl HostDefined {
                 host_defined,
                 Attribute::all(),
             )
-            .unwrap_or_else(|_| {
-                panic!("{:?} object should only be defined once", Self::NAME)
-            })
+            .expect(&format!(
+                "{:?} object should only be defined once",
+                Self::NAME
+            ))
     }
 }
 

--- a/crates/jstz_core/src/realm.rs
+++ b/crates/jstz_core/src/realm.rs
@@ -303,10 +303,9 @@ impl HostDefined {
                 host_defined,
                 Attribute::all(),
             )
-            .expect(&format!(
-                "{:?} object should only be defined once",
-                Self::NAME
-            ))
+            .unwrap_or_else(|_| {
+                panic!("{:?} object should only be defined once", Self::NAME)
+            })
     }
 }
 

--- a/crates/jstz_core/src/realm.rs
+++ b/crates/jstz_core/src/realm.rs
@@ -176,7 +176,7 @@ type HostDefinedMap = HashMap<TracedTypeId, GcRefCell<Box<dyn NativeObject>>>;
 /// objects.
 ///
 /// This allows storing types which are mapped by their [`TypeId`].
-#[derive(Trace, Finalize)]
+#[derive(Trace, Finalize, Default)]
 pub struct HostDefined {
     env: HostDefinedMap,
 }
@@ -190,9 +190,7 @@ unsafe fn downcast_boxed_native_object_unchecked<T: NativeObject>(
 
 impl HostDefined {
     pub fn new() -> Self {
-        Self {
-            env: HashMap::new(),
-        }
+        Self::default()
     }
 
     #[track_caller]

--- a/crates/jstz_core/src/value.rs
+++ b/crates/jstz_core/src/value.rs
@@ -5,7 +5,7 @@ use boa_engine::{
         JsMapIterator, JsPromise, JsProxy, JsRegExp, JsSet, JsSetIterator, JsTypedArray,
         JsUint16Array, JsUint32Array, JsUint8Array,
     },
-    Context, JsBigInt, JsObject, JsString, JsSymbol, JsValue,
+    Context, JsBigInt, JsObject, JsString, JsSymbol,
 };
 
 pub use boa_engine::value::*;

--- a/crates/jstz_core/src/value.rs
+++ b/crates/jstz_core/src/value.rs
@@ -100,6 +100,6 @@ where
         for val in self.into_iter() {
             values.push(val.into_js(context));
         }
-        JsArray::from_iter(values.into_iter(), context).into()
+        JsArray::from_iter(values, context).into()
     }
 }

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -14,7 +14,7 @@ pub mod inbox;
 const TICKETER: RefPath = RefPath::assert_from(b"/ticketer");
 
 fn read_ticketer(rt: &impl Runtime) -> Option<ContractKt1Hash> {
-    Some(Storage::get(rt, &TICKETER).ok()??)
+    Storage::get(rt, &TICKETER).ok()?
 }
 
 fn handle_message(hrt: &mut (impl Runtime + 'static), message: Message) -> Result<()> {

--- a/crates/jstz_node/src/main.rs
+++ b/crates/jstz_node/src/main.rs
@@ -18,11 +18,11 @@ mod services;
 mod tailed_file;
 
 /// Endpoint details for the `octez-smart-rollup-node`
-const DEFAULT_ROLLUP_NODE_RPC_ADDR: &'static str = "127.0.0.1";
+const DEFAULT_ROLLUP_NODE_RPC_ADDR: &str = "127.0.0.1";
 const DEFAULT_ROLLUP_RPC_PORT: u16 = 8932;
 
 /// Endpoint defailts for the `jstz-node`
-const ENDPOINT: (&'static str, u16) = ("127.0.0.1", 8933);
+const ENDPOINT: (&str, u16) = ("127.0.0.1", 8933);
 
 #[derive(Debug, Parser)]
 struct Args {

--- a/crates/jstz_node/src/tailed_file.rs
+++ b/crates/jstz_node/src/tailed_file.rs
@@ -12,7 +12,7 @@ impl TailedFile {
         let _ = file.seek(SeekFrom::End(0));
         let reader = BufReader::new(file);
 
-        return Ok(TailedFile(reader));
+        Ok(TailedFile(reader))
     }
 
     pub fn lines(self) -> Lines<BufReader<File>> {

--- a/crates/jstz_proto/src/api/contract.rs
+++ b/crates/jstz_proto/src/api/contract.rs
@@ -31,7 +31,7 @@ unsafe impl Trace for Contract {
 }
 
 impl Contract {
-    fn from_js_value<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn from_js_value(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -51,7 +51,7 @@ impl Contract {
     ) -> Result<String> {
         // 1. Check if the contract has sufficient balance
         if Account::balance(hrt, tx, &self.contract_address)? < initial_balance {
-            return Err(Error::BalanceOverflow.into());
+            return Err(Error::BalanceOverflow);
         }
 
         // 2. Deploy the contract

--- a/crates/jstz_proto/src/api/ledger.rs
+++ b/crates/jstz_proto/src/api/ledger.rs
@@ -77,7 +77,7 @@ pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<Address> {
 }
 
 impl Ledger {
-    fn try_from_js<'a>(value: &'a JsValue) -> JsResult<GcRefMut<'a, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -133,7 +133,7 @@ impl LedgerApi {
             let amount = args
                 .get_or_undefined(1)
                 .as_number()
-                .ok_or_else(|| JsNativeError::typ())?;
+                .ok_or_else(JsNativeError::typ)?;
 
             ledger.transfer(rt.deref(), tx.deref_mut(), &dst, amount as Amount)?;
 

--- a/crates/jstz_proto/src/executor/contract.rs
+++ b/crates/jstz_proto/src/executor/contract.rs
@@ -188,7 +188,7 @@ impl Script {
     ) -> JsResult<JsPromise> {
         self.register_apis(contract_address, context, operation_hash);
 
-        self.realm().eval_module(&self, context)
+        self.realm().eval_module(self, context)
     }
 
     /// Deploys a script
@@ -202,13 +202,7 @@ impl Script {
         let nonce = Account::nonce(hrt, tx, source)?;
 
         let address = Address::digest(
-            format!(
-                "{}{}{}",
-                source.to_string(),
-                code.to_string(),
-                nonce.to_string(),
-            )
-            .as_bytes(),
+            format!("{}{}{}", source, code, nonce.to_string(),).as_bytes(),
         )?;
 
         Account::create(hrt, tx, &address, balance, Some(code))?;
@@ -254,7 +248,7 @@ impl Script {
                     );
 
                     let response =
-                        Response::try_from_js(&value).expect("Expected valid response");
+                        Response::try_from_js(value).expect("Expected valid response");
 
                     // If status code is 2xx, commit transaction
                     if response.ok() {
@@ -343,7 +337,7 @@ pub mod run {
         register_web_apis(&rt.realm().clone(), rt);
 
         // 2. Extract address from request
-        let address = Address::from_base58(&uri.host().expect("Expected host"))?;
+        let address = Address::from_base58(uri.host().expect("Expected host"))?;
 
         // 3. Deserialize request
         let http_request = create_http_request(uri, method, headers, body);

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -61,7 +61,7 @@ impl Operation {
             }) => Blake2b::from(
                 format!(
                     "{}{}{}{}",
-                    source.to_string(),
+                    source,
                     nonce.to_string(),
                     contract_code,
                     contract_credit
@@ -77,7 +77,7 @@ impl Operation {
             }) => Blake2b::from(
                 format!(
                     "{}{}{}{}{:?}{:?}",
-                    source.to_string(),
+                    source,
                     nonce.to_string(),
                     uri,
                     method,

--- a/crates/jstz_wpt/src/lib.rs
+++ b/crates/jstz_wpt/src/lib.rs
@@ -73,7 +73,7 @@ impl Wpt {
     pub fn doctor() -> Result<Diagnosis> {
         let python_installed = {
             let python_version = run_python(
-                &["--version"],
+                ["--version"],
                 PythonOptions {
                     stdout: Stdio::piped(),
                     ..Default::default()
@@ -118,7 +118,7 @@ impl Wpt {
         let args = [WPT_CMD, "make-hosts-file"];
 
         let output = run_python(
-            &args,
+            args,
             PythonOptions {
                 stdout: Stdio::piped(),
                 ..Default::default()
@@ -183,7 +183,7 @@ impl Wpt {
             Default::default()
         };
 
-        let mut child = run_python(&args, options)?;
+        let mut child = run_python(args, options)?;
 
         // Wait for the server to start
         let mut attempts = 0;

--- a/crates/jstz_wpt/src/manifest.rs
+++ b/crates/jstz_wpt/src/manifest.rs
@@ -81,12 +81,12 @@ impl TryFrom<internal::WptManifestTest> for WptManifestTest {
     }
 }
 
-impl Into<internal::WptManifestTest> for WptManifestTest {
-    fn into(self) -> internal::WptManifestTest {
-        let mut items = vec![internal::WptManifestTestItem::Hash(self.hash)];
+impl From<WptManifestTest> for internal::WptManifestTest {
+    fn from(val: WptManifestTest) -> Self {
+        let mut items = vec![internal::WptManifestTestItem::Hash(val.hash)];
 
         items.extend(
-            self.variations
+            val.variations
                 .into_iter()
                 .map(internal::WptManifestTestItem::Variations),
         );
@@ -111,9 +111,9 @@ impl From<(Option<String>, WptTestOptions)> for WptTestVariation {
     }
 }
 
-impl Into<(Option<String>, WptTestOptions)> for WptTestVariation {
-    fn into(self) -> (Option<String>, WptTestOptions) {
-        (self.path, self.options)
+impl From<WptTestVariation> for (Option<String>, WptTestOptions) {
+    fn from(val: WptTestVariation) -> Self {
+        (val.path, val.options)
     }
 }
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+cp ./scripts/pre-push-hook.sh .git/hooks/pre-push
 cp ./scripts/pre-commit-hook.sh .git/hooks/pre-commit
 cp ./scripts/commit-msg-hook.sh .git/hooks/commit-msg
-chmod +x .git/hooks/pre-commit .git/hooks/commit-msg
+chmod +x .git/hooks/pre-commit .git/hooks/commit-msg .git/hooks/pre-push
 echo "Successfully installed git hooks (scripts/*-hook.sh) into .git/hooks/*"

--- a/scripts/pre-push-hook.sh
+++ b/scripts/pre-push-hook.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+# Run linting
+make lint
+
+# Check if linting passed
+if [ $? -ne 0 ]; then
+  echo "Linting failed. Aborting push."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
# Context
This PR introduces a new command `make lint` that uses clippy and apply them during pre-push / pipeline.

Additionally, i refactored the code so that there will be no linting warnings. The first commit is auto generated by cargo clippy and i manually fixed the linting issues in the last commit.

Make sure you run `scripts/install-hooks.sh` to install the pre-push-hook script. 

**Asana Task**: [Add linting to ci/pre-push hook](https://app.asana.com/0/1205770721173531/1206077181649731/f)


# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
* pipeline: we can see [here](https://github.com/trilitech/jstz/actions/runs/7185008193/job/19567349006?pr=269) that the lint job throws error
* pre-push-hook: run `scripts/install-hooks.sh` to install the pre-push-hook script and try pushing with warnings. 