### PR TITLE
Health: Fix panics (low hanging fruit)

### DIFF
--- a/crates/jstz_api/src/console.rs
+++ b/crates/jstz_api/src/console.rs
@@ -41,15 +41,13 @@ pub struct LogRecord {
 
 impl Display for LogRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(
-            &serde_json::to_string(self).expect("Failed to convert LogRecord to string"),
-        )
+        f.write_str(&serde_json::to_string(self).map_err(|_| std::fmt::Error)?)
     }
 }
 
 impl LogRecord {
-    pub fn from_string(json: &str) -> Self {
-        serde_json::from_str(json).expect("Failed to deserialize JSONLog")
+    pub fn try_from_string(json: &str) -> Option<Self> {
+        serde_json::from_str(json).ok()
     }
 }
 

--- a/crates/jstz_api/src/encoding/text_decoder.rs
+++ b/crates/jstz_api/src/encoding/text_decoder.rs
@@ -218,7 +218,9 @@ impl TextDecoder {
         let mut output: Vec<u16> = Vec::with_capacity(
             self.decoder
                 .max_utf16_buffer_length(input.len())
-                .expect("If usize overflows, then we cannot alloc this"),
+                .ok_or_else(|| {
+                    JsNativeError::eval().with_message("Input too large for buffer")
+                })?,
         );
         output.resize(output.capacity(), 0);
 

--- a/crates/jstz_api/src/encoding/text_encoder.rs
+++ b/crates/jstz_api/src/encoding/text_encoder.rs
@@ -138,7 +138,9 @@ impl TextEncoder {
         let mut buffer: Vec<u8> = Vec::with_capacity(
             encoder
                 .max_buffer_length_from_utf16_if_no_unmappables(input.len())
-                .expect("If usize overflows, then we cannot alloc this"),
+                .ok_or_else(|| {
+                    JsNativeError::eval().with_message("Input too large for buffer")
+                })?,
         );
         buffer.resize(buffer.capacity(), 0);
 

--- a/crates/jstz_api/src/http/header.rs
+++ b/crates/jstz_api/src/http/header.rs
@@ -361,7 +361,12 @@ impl TryFromJs for HeadersInit {
                 context,
             )?
             .to_object(context)
-            .expect("Expected array from `Object.entries`");
+            .map_err(|_| {
+                JsError::from_native(
+                    JsNativeError::typ()
+                        .with_message("Expected array from `Object.entries`"),
+                )
+            })?;
 
             Ok(Self::New(js_array_to_header_entries(&arr, context)?))
         }

--- a/crates/jstz_api/src/http/response.rs
+++ b/crates/jstz_api/src/http/response.rs
@@ -263,7 +263,10 @@ impl ResponseBuilder {
         let headers = Headers::new();
 
         Ok(Response {
-            response: InnerResponse::builder().status(status).body(body).unwrap(),
+            response: InnerResponse::builder()
+                .status(status)
+                .body(body)
+                .expect("fixed inputs should never fail"),
             headers: JsNativeObject::new::<HeadersClass>(headers, context)?,
             url: None,
         })
@@ -314,7 +317,7 @@ impl ResponseBuilder {
             response: InnerResponse::builder()
                 .status(status)
                 .body(Body::null())
-                .unwrap(),
+                .expect("fixed inputs should never fail"),
             headers: JsNativeObject::new::<HeadersClass>(headers, context)?,
             url: Some(parsed_url),
         })

--- a/crates/jstz_api/tests/wpt.rs
+++ b/crates/jstz_api/tests/wpt.rs
@@ -214,15 +214,15 @@ impl jstz_core::Api for TestHarnessReportApi {
             let value = context
                 .global_object()
                 .get(js_string!(name), context)
-                .expect(&format!("globalThis.{} is undefined", name));
+                .unwrap_or_else(|_| panic!("globalThis.{} is undefined", name));
 
             let function = value
                 .as_callable()
-                .expect(&format!("globalThis.{} is not callable", name));
+                .unwrap_or_else(|| panic!("globalThis.{} is not callable", name));
 
             function
                 .call(&JsValue::undefined(), args, context)
-                .expect(&format!("Failed to call globalThis.{}", name));
+                .unwrap_or_else(|_| panic!("Failed to call globalThis.{}", name));
         }
 
         call_global_function(

--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -181,7 +181,9 @@ fn smart_rollup_installer(cfg: &Config, bridge_address: &str) -> Result<()> {
 
     let instructions = YamlConfig {
         instructions: vec![Instr::Set(SetArgs {
-            value: hex::encode(serialize(&bridge_address)),
+            value: hex::encode(
+                serialize(&bridge_address).expect("Could not serialize address"),
+            ),
             to: "/ticketer".to_owned(),
         })],
     };

--- a/crates/jstz_core/src/error.rs
+++ b/crates/jstz_core/src/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
     JsError {
         source: JsError,
     },
+    SerializationError {
+        description: String,
+    },
 }
 
 impl From<Error> for JsError {
@@ -26,6 +29,9 @@ impl From<Error> for JsError {
             Error::JsError { source } => JsNativeError::eval()
                 .with_message("JsError")
                 .with_cause(source)
+                .into(),
+            Error::SerializationError { description } => JsNativeError::eval()
+                .with_message(format!("serialization error: {description}"))
                 .into(),
         }
     }

--- a/crates/jstz_core/src/kv/mod.rs
+++ b/crates/jstz_core/src/kv/mod.rs
@@ -55,7 +55,7 @@ impl Storage {
         match rt.store_has(key)? {
             Some(ValueType::Value | ValueType::ValueWithSubtree) => {
                 let bytes = rt.store_read_all(key)?;
-                let value = value::deserialize(&bytes);
+                let value = value::deserialize(&bytes)?;
                 Ok(Some(value))
             }
             _ => Ok(None),
@@ -76,7 +76,7 @@ impl Storage {
     where
         V: Value + ?Sized,
     {
-        rt.store_write(key, &value::serialize(value), 0)?;
+        rt.store_write(key, &value::serialize(value)?, 0)?;
         Ok(())
     }
 

--- a/crates/jstz_core/src/realm.rs
+++ b/crates/jstz_core/src/realm.rs
@@ -301,10 +301,9 @@ impl HostDefined {
                 host_defined,
                 Attribute::all(),
             )
-            .expect(&format!(
-                "{:?} object should only be defined once",
-                Self::NAME
-            ))
+            .unwrap_or_else(|_| {
+                panic!("{:?} object should only be defined once", Self::NAME)
+            })
     }
 }
 

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -60,7 +60,8 @@ impl LogsService {
                 line = lines.next_line() => {
                     if let Ok(Some(msg)) = line {
                         if msg.starts_with(LOG_PREFIX) {
-                            let log = LogRecord::from_string(&msg[LOG_PREFIX.len()..]);
+                            let log = LogRecord::try_from_string(&msg[LOG_PREFIX.len()..])
+                                .unwrap();
                             broadcaster.broadcast(&log.contract_address, &msg[LOG_PREFIX.len()..]).await;
                         }
                     }

--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     InvalidAddress,
     RefererShouldNotBeSet,
     GasLimitExceeded,
+    InvalidHttpRequest,
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -34,6 +35,9 @@ impl From<Error> for JsError {
                 .into(),
             Error::GasLimitExceeded => JsNativeError::eval()
                 .with_message("GasLimitExceeded")
+                .into(),
+            Error::InvalidHttpRequest => JsNativeError::eval()
+                .with_message("InvalidHttpRequest")
                 .into(),
         }
     }

--- a/crates/jstz_proto/src/executor/contract.rs
+++ b/crates/jstz_proto/src/executor/contract.rs
@@ -245,7 +245,7 @@ impl Script {
                         "Rust type `Transaction` should be defined in `HostDefined`",
                     );
 
-                    let response = Response::try_from_js(&value)?;
+                    let response = Response::try_from_js(value)?;
 
                     // If status code is 2xx, commit transaction
                     if response.ok() {
@@ -333,7 +333,7 @@ pub mod run {
         register_web_apis(&rt.realm().clone(), rt);
 
         // 2. Extract address from request
-        let address = Address::from_base58(&uri.host().ok_or(Error::InvalidAddress)?)?;
+        let address = Address::from_base58(uri.host().ok_or(Error::InvalidAddress)?)?;
 
         // 3. Deserialize request
         let http_request = create_http_request(uri, method, headers, body)?;


### PR DESCRIPTION
# Context
This PR replaces several uses of `.expect()` and `.unwrap()` which could cause the rollup to panic. 

**Related Tasks**: [Analyze all possible panics](https://app.asana.com/0/1205770721173531/1206072089048483/f)

# Description
Calls to `.expect` and `.unwrap` are replaced wherever possible by converting to a result.  This reduces instances where the rollup may panic.

* Focus is on the areas where the rollup kernel would panic, `jstz_cli` and `jstz_node` may still panic.
* Panics caused by a programmer error in rust (such as interactions with `HostDefined` are not addressed. 
* There is no claim that this is exhaustive. Only the easy fixes have been addressed.

