### PR TITLE
Node: Fix file read and refactor

### DIFF
--- a/crates/jstz_node/src/services/accounts.rs
+++ b/crates/jstz_node/src/services/accounts.rs
@@ -12,6 +12,8 @@ use octez::OctezRollupClient;
 
 use crate::Result;
 
+use super::Service;
+
 fn construct_storage_key(address: &str, key: &Option<String>) -> String {
     match key {
         Some(value) if !value.is_empty() => format!("/jstz_kv/{}/{}", address, value),
@@ -128,8 +130,8 @@ async fn kv_subkeys(
 
 pub struct AccountsService;
 
-impl AccountsService {
-    pub fn configure(cfg: &mut ServiceConfig) {
+impl Service for AccountsService {
+    fn configure(cfg: &mut ServiceConfig) {
         let scope = Scope::new("/accounts")
             .service(nonce)
             .service(code)

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -37,7 +37,6 @@ pub struct LogsService;
 impl Service for LogsService {
     fn configure(cfg: &mut ServiceConfig) {
         let scope = Scope::new("/logs").service(stream_logs);
-
         cfg.service(scope);
     }
 }

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -1,8 +1,8 @@
 use crate::tailed_file::TailedFile;
 use actix_web::{
     get,
-    web::{Data, Path},
-    Responder,
+    web::{Data, Path, ServiceConfig},
+    Responder, Scope,
 };
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_proto::js_logger::{LogRecord, LOG_PREFIX};
@@ -13,6 +13,8 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use self::broadcaster::Broadcaster;
+
+use super::Service;
 
 pub mod broadcaster;
 
@@ -31,6 +33,14 @@ async fn stream_logs(
 }
 
 pub struct LogsService;
+
+impl Service for LogsService {
+    fn configure(cfg: &mut ServiceConfig) {
+        let scope = Scope::new("/logs").service(stream_logs);
+
+        cfg.service(scope);
+    }
+}
 
 impl LogsService {
     // Initalise the LogService by spawning a future that reads and broadcasts the file

--- a/crates/jstz_node/src/services/mod.rs
+++ b/crates/jstz_node/src/services/mod.rs
@@ -3,6 +3,10 @@ pub mod logs;
 mod operations;
 
 pub use accounts::AccountsService;
+use actix_web::web::ServiceConfig;
+pub use logs::LogsService;
 pub use operations::OperationsService;
 
-pub use logs::LogsService;
+pub trait Service {
+    fn configure(cfg: &mut ServiceConfig);
+}

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -9,6 +9,8 @@ use octez::OctezRollupClient;
 
 use crate::Result;
 
+use super::Service;
+
 #[get("/{hash}/receipt")]
 async fn receipt(
     rollup_client: Data<OctezRollupClient>,
@@ -29,8 +31,8 @@ async fn receipt(
 
 pub struct OperationsService;
 
-impl OperationsService {
-    pub fn configure(cfg: &mut ServiceConfig) {
+impl Service for OperationsService {
+    fn configure(cfg: &mut ServiceConfig) {
         let scope = Scope::new("/operations").service(receipt);
 
         cfg.service(scope);

--- a/crates/jstz_node/src/tailed_file.rs
+++ b/crates/jstz_node/src/tailed_file.rs
@@ -8,10 +8,9 @@ pub use tokio::io::AsyncBufReadExt;
 
 impl TailedFile {
     pub async fn init(path: &str) -> Result<Self> {
-        let mut file = File::open(path).await?;
-        let _ = file.seek(SeekFrom::End(0));
-        let reader = BufReader::new(file);
-
+        let file = File::open(path).await?;
+        let mut reader = BufReader::new(file);
+        let _ = reader.seek(SeekFrom::End(0)).await?;
         Ok(TailedFile(reader))
     }
 


### PR DESCRIPTION
# Context

* There was a bug where the file read buffer wasn't sought to the end of the log file as expected.
* Previously the LogsService didn't follow the `configure` style (in `jstz_node/src/main.rs`) in order to limit the visibility of the `broadcaster` struct. However this isn't that big of an issue given each endpoint can only access one data anyway.

# Description
* Refactors the jstz-node service by introducing the `Service` trait
* Fix the issue with the file seek problem 
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
Ran the jstz-node services. 
The following screenrecords shows that the logging service works as expected and doesn't read the old content of the file anymore.

https://github.com/trilitech/jstz/assets/128799322/f12156d5-dcd9-4340-bc06-dbdb1ff6e22e

