### PR TITLE
Cli: Filter logs by --level

### DIFF
--- a/crates/jstz_api/src/js_log.rs
+++ b/crates/jstz_api/src/js_log.rs
@@ -1,13 +1,30 @@
 use boa_engine::{Context, JsNativeError, JsResult};
 use serde::{Deserialize, Serialize};
 use std::cell::Cell;
+use std::str::FromStr;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LogLevel {
-    ERROR,
-    WARN,
-    INFO,
-    LOG,
+    ERROR = 1,
+    WARN = 2,
+    INFO = 3,
+    LOG = 4,
+}
+
+pub const DEFAULT_LOG_LOG_LEVEL: LogLevel = LogLevel::LOG;
+
+impl FromStr for LogLevel {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "ERROR" => Ok(LogLevel::ERROR),
+            "WARN" => Ok(LogLevel::WARN),
+            "INFO" => Ok(LogLevel::INFO),
+            "LOG" => Ok(LogLevel::LOG),
+            _ => Err("no match"),
+        }
+    }
 }
 
 impl LogLevel {

--- a/crates/jstz_cli/src/logs/mod.rs
+++ b/crates/jstz_cli/src/logs/mod.rs
@@ -12,11 +12,14 @@ pub enum Command {
         // The address or the alias of the smart function
         #[arg(value_name = "ALIAS|ADDRESS")]
         smart_function: String,
+        // Optional log level to filter log stream
+        #[arg(name = "level", short, long)]
+        log_level_str: Option<String>,
     },
 }
 
 pub async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
     match command {
-        Command::Trace { smart_function } => trace::exec(smart_function, cfg).await,
+        Command::Trace { smart_function, log_level_str } => trace::exec(smart_function, log_level_str, cfg).await,
     }
 }

--- a/crates/jstz_cli/src/logs/trace.rs
+++ b/crates/jstz_cli/src/logs/trace.rs
@@ -1,10 +1,13 @@
+use std::str::FromStr;
+
 use crate::Config;
 use anyhow::Result;
 use futures_util::stream::StreamExt;
+use jstz_api::js_log::{LogLevel, DEFAULT_LOG_LOG_LEVEL};
 use jstz_proto::js_logger::LogRecord;
 use reqwest_eventsource::{Event, EventSource};
 
-pub async fn exec(address_or_alias: String, cfg: &Config) -> Result<()> {
+pub async fn exec(address_or_alias: String, log_level_str: Option<String>, cfg: &Config) -> Result<()> {
     let address = cfg.accounts.get_address(&address_or_alias)?;
     let url = format!(
         "http://127.0.0.1:{}/logs/{}/stream",
@@ -14,13 +17,17 @@ pub async fn exec(address_or_alias: String, cfg: &Config) -> Result<()> {
 
     let mut event_source = EventSource::get(&url);
 
+    let log_level = LogLevel::from_str(&log_level_str.unwrap_or_default()).unwrap_or(DEFAULT_LOG_LOG_LEVEL);
+
     while let Some(event) = event_source.next().await {
         match event {
             Ok(Event::Open) => println!("Connection open with {}", url),
             Ok(Event::Message(message)) => {
                 if let Ok(log_record) = serde_json::from_str::<LogRecord>(&message.data) {
                     let LogRecord { level, text, .. } = log_record;
-                    println!("[{}]: {}", level.symbol(), text);
+                    if level <= log_level {
+                        println!("[{}]: {}", level.symbol(), text);
+                    }
                 }
             }
             Err(err) => {


### PR DESCRIPTION
## Context
https://app.asana.com/0/1205770721173531/1205770721347940/f

## Description
This PR adds log filtering by levels (LOG, INFO, WARN, ERROR) to the jstz-cli. The newly added optional --level or -l flag takes one of the log levels and stream logs with that level of logs or higher precedence. 

If the --level flag is not mentioned, then all the available types of logs are streamed.

## Testing
1. Started jstz sandbox and a jstz node.
2. Deployed `examples/logs.js` contract.
3. Ran `cargo run --bin jstz logs trace <address> --level warn` in a separate tab.
4. Ran the contract.

## Demo
1. With `--level`
```
$ cargo run --bin jstz logs trace tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6 --level warn
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
   Compiling jstz_api v0.1.0 (/Users/faisal/code/jstz/crates/jstz_api)
   Compiling jstz_proto v0.1.0 (/Users/faisal/code/jstz/crates/jstz_proto)
   Compiling jstz_kernel v0.1.0 (/Users/faisal/code/jstz/crates/jstz_kernel)
   Compiling jstz_cli v0.1.0 (/Users/faisal/code/jstz/crates/jstz_cli)
    Finished dev [unoptimized + debuginfo] target(s) in 3.95s
warning: the following packages contain code that will be rejected by a future version of Rust: parse-display-derive v0.4.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/jstz logs trace tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6 --level warn`
Connection open with http://127.0.0.1:8933/logs/tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6/stream
[🟠]: warn
[🔴]: error
[🔴]: Assertion failed
```
2. Without
```
$ cargo run --bin jstz logs trace tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
warning: the following packages contain code that will be rejected by a future version of Rust: parse-display-derive v0.4.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/jstz logs trace tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6`
Connection open with http://127.0.0.1:8933/logs/tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6/stream
[🪵]: log
[🪵]: debug
[🟢]: info
[🟠]: warn
[🔴]: error
[🔴]: Assertion failed
```



