### PR TITLE
cli: filter logs by --level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "bytes",
+ "clap",
  "derive_more",
  "encoding_rs",
  "expect-test",

--- a/crates/jstz_api/Cargo.toml
+++ b/crates/jstz_api/Cargo.toml
@@ -22,6 +22,7 @@ url = "2.4.1"
 urlpattern = "0.2.0"
 encoding_rs = "0.8.33"
 fastrand = "2.0.1"
+clap = { version = "^4.4", features = ["derive"] }
 
 [dev-dependencies]
 anyhow = "1.0.75"

--- a/crates/jstz_api/src/js_log.rs
+++ b/crates/jstz_api/src/js_log.rs
@@ -1,13 +1,14 @@
 use boa_engine::{Context, JsNativeError, JsResult};
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::cell::Cell;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Clone, ValueEnum)]
 pub enum LogLevel {
-    ERROR,
-    WARN,
-    INFO,
-    LOG,
+    ERROR = 1,
+    WARN = 2,
+    INFO = 3,
+    LOG = 4,
 }
 
 impl ToString for LogLevel {

--- a/crates/jstz_cli/src/logs/mod.rs
+++ b/crates/jstz_cli/src/logs/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Subcommand;
+use jstz_api::js_log::LogLevel;
 
 use crate::config::Config;
 
@@ -12,11 +13,17 @@ pub enum Command {
         // The address or the alias of the smart function
         #[arg(value_name = "ALIAS|ADDRESS")]
         smart_function: String,
+        // Optional log level to filter log stream
+        #[arg(name = "level", short, long, ignore_case = true)]
+        log_level: Option<LogLevel>,
     },
 }
 
 pub async fn exec(command: Command, cfg: &mut Config) -> Result<()> {
     match command {
-        Command::Trace { smart_function } => trace::exec(smart_function, cfg).await,
+        Command::Trace {
+            smart_function,
+            log_level,
+        } => trace::exec(smart_function, log_level, cfg).await,
     }
 }


### PR DESCRIPTION
## Context
https://app.asana.com/0/1205770721173531/1205770721347940/f

## Description
This PR adds log filtering by levels (LOG, INFO, WARN, ERROR) to the jstz-cli. The newly added optional --level or -l flag takes one of the log levels and stream logs with that level of logs or higher precedence. 

If the --level flag is not mentioned, then all the available types of logs are streamed.

## Testing
1. Started jstz sandbox and a jstz node.
2. Deployed `examples/logs.js` contract.
3. Ran `cargo run --bin jstz logs trace <address> --level warn` in a separate tab.
4. Ran the contract.

## Demo
1. With `--level`
```
$ cargo run --bin jstz logs trace tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6 --level warn
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
   Compiling jstz_api v0.1.0 (/Users/faisal/code/jstz/crates/jstz_api)
   Compiling jstz_proto v0.1.0 (/Users/faisal/code/jstz/crates/jstz_proto)
   Compiling jstz_kernel v0.1.0 (/Users/faisal/code/jstz/crates/jstz_kernel)
   Compiling jstz_cli v0.1.0 (/Users/faisal/code/jstz/crates/jstz_cli)
    Finished dev [unoptimized + debuginfo] target(s) in 3.95s
warning: the following packages contain code that will be rejected by a future version of Rust: parse-display-derive v0.4.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/jstz logs trace tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6 --level warn`
Connection open with http://127.0.0.1:8933/logs/tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6/stream
[🟠]: warn
[🔴]: error
[🔴]: Assertion failed
```
2. Without
```
$ cargo run --bin jstz logs trace tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
warning: the following packages contain code that will be rejected by a future version of Rust: parse-display-derive v0.4.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/jstz logs trace tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6`
Connection open with http://127.0.0.1:8933/logs/tz4MRUzq2DD3dzx2F6sCeeD1kfpK9ejgBsz6/stream
[🪵]: log
[🪵]: debug
[🟢]: info
[🟠]: warn
[🔴]: error
[🔴]: Assertion failed
```




