### PR TITLE
Node: Proxy external inbox messages via `jstz-node`

### DIFF
--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -7,7 +7,6 @@ use jstz_proto::{
 use crate::{
     account::account::OwnedAccount,
     config::Config,
-    sandbox::CLIENT_ADDRESS,
     utils::{from_file_or_id, piped_input},
 };
 
@@ -66,8 +65,7 @@ pub async fn exec(
     );
 
     // Send message to jstz
-    cfg.octez_client()?
-        .send_rollup_external_message(CLIENT_ADDRESS, bincode::serialize(&signed_op)?)?;
+    cfg.jstz_client()?.post_operation(&signed_op).await?;
 
     let receipt = jstz_client.wait_for_operation_receipt(&hash).await?;
 

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use anyhow::Result;
 use jstz_api::KvValue;
+use jstz_proto::operation::SignedOperation;
 use jstz_proto::{context::account::Nonce, operation::OperationHash, receipt::Receipt};
 use reqwest::StatusCode;
 use tokio::time::sleep;
@@ -140,7 +141,22 @@ impl JstzClient {
             }
 
             // tokio sleep
-            sleep(Duration::from_millis(100)).await;
+            sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    pub async fn post_operation(&self, operation: &SignedOperation) -> Result<()> {
+        let response = self
+            .client
+            .post(&format!("{}/operations", self.endpoint))
+            .body(bincode::serialize(operation)?)
+            .send()
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(()),
+            // For any other status, return a generic error
+            _ => Err(anyhow!("Failed to post operation")),
         }
     }
 

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -8,7 +8,6 @@ use url::Url;
 use crate::{
     account::account::OwnedAccount,
     config::Config,
-    sandbox::CLIENT_ADDRESS,
     utils::{from_file_or_id, piped_input},
 };
 
@@ -95,8 +94,7 @@ pub async fn exec(
     );
 
     // Send message
-    cfg.octez_client()?
-        .send_rollup_external_message(CLIENT_ADDRESS, bincode::serialize(&signed_op)?)?;
+    cfg.jstz_client()?.post_operation(&signed_op).await?;
 
     let receipt = jstz_client.wait_for_operation_receipt(&hash).await?;
 

--- a/crates/jstz_cli/src/sandbox/mod.rs
+++ b/crates/jstz_cli/src/sandbox/mod.rs
@@ -7,8 +7,6 @@ use nix::{
 
 mod daemon;
 
-pub(crate) use daemon::CLIENT_ADDRESS;
-
 use crate::config::Config;
 
 #[derive(Subcommand)]

--- a/crates/jstz_node/src/main.rs
+++ b/crates/jstz_node/src/main.rs
@@ -14,12 +14,13 @@ mod error;
 mod services;
 mod tailed_file;
 
-/// Endpoint details for the `octez-smart-rollup-node`
+/// Endpoint defaults for the `octez-smart-rollup-node`
 const DEFAULT_ROLLUP_NODE_RPC_ADDR: &str = "127.0.0.1";
 const DEFAULT_ROLLUP_RPC_PORT: u16 = 8932;
 
-/// Endpoint defailts for the `jstz-node`
-const ENDPOINT: (&str, u16) = ("127.0.0.1", 8933);
+/// Endpoint defaults for the `jstz-node`
+const DEFAULT_JSTZ_NODE_ADDR: &str = "127.0.0.1";
+const DEFAULT_JSTZ_NODE_PORT: u16 = 8933;
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -31,6 +32,12 @@ struct Args {
 
     #[arg(short, long)]
     rollup_endpoint: Option<String>,
+
+    #[arg(long, default_value = DEFAULT_JSTZ_NODE_ADDR)]
+    addr: String,
+
+    #[arg(long, default_value_t = DEFAULT_JSTZ_NODE_PORT)]
+    port: u16,
 
     #[arg(long)]
     kernel_file_path: String,
@@ -63,7 +70,7 @@ async fn main() -> io::Result<()> {
             .configure(LogsService::configure)
             .wrap(Logger::default())
     })
-    .bind(ENDPOINT)?
+    .bind((args.addr, args.port))?
     .run()
     .await?;
 

--- a/crates/octez/src/rollup.rs
+++ b/crates/octez/src/rollup.rs
@@ -103,6 +103,31 @@ impl OctezRollupClient {
         }
     }
 
+    pub async fn batcher_injection<S, I>(&self, external_messages: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<[u8]>,
+    {
+        let res = self
+            .client
+            .post(format!("{}/local/batcher/injection", self.endpoint))
+            .json(
+                &external_messages
+                    .into_iter()
+                    .map(hex::encode)
+                    .collect::<Vec<String>>(),
+            )
+            .send()
+            .await?;
+
+        if res.status() == 200 {
+            // TODO: Should we ignore the response?
+            Ok(())
+        } else {
+            Err(anyhow!("Unhandled response status: {}", res.status()))
+        }
+    }
+
     pub async fn get_value(&self, key: &str) -> Result<Option<Vec<u8>>> {
         let res = self
             .client


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Proxy external messages from `jstz-node` to the rollup node](https://app.asana.com/0/1205770721173531/1206249753769937/f) 

This PR introduces a proxy for external inbox messages to the jstz rollup using the `jstz-node`. This avoids
the CLI directly communicating with the `octez-node`. 

The only direct`octez-node` dependencies are in the sandbox (not removable for now) and L1 account deposits. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR adds a `POST` endpoint to the `/operations` service, permitting the injection of operations via the `jstz-node` instead of using the `octez-node`. 

**Note**: There seems to be an issue with the JSON serialization and deserialization of BLS signatures with `actix-web`, this could be fixed by #320. For now we just directly pass bytes, but in future (when implementing IDL definitions for `jstz-node`) we will provide the correct de+serializers. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Startup the sandbox and deploy / run any smart function :) 