### PR TITLE
Node: configure SQL to store logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1236,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fast-float"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1509,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2005,15 +2033,20 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
+ "dirs",
  "env_logger",
  "futures-util",
  "hex",
  "jstz_api",
  "jstz_crypto",
  "jstz_proto",
+ "load_file",
  "octez",
  "parking_lot 0.12.1",
+ "r2d2",
+ "r2d2_sqlite",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "thiserror",
@@ -2174,6 +2207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-wrap"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2242,12 @@ name = "litemap"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d642685b028806386b2b6e75685faadd3eb65a85fff7df711ce18446a422da"
+
+[[package]]
+name = "load_file"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31da4bce62428941030036a44d0d4b123f031b04080f8aeb44248b41de3e79cd"
 
 [[package]]
 name = "local-channel"
@@ -2848,6 +2897,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot 0.12.1",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f31323d6161385f385046738df520e0e8694fa74852d35891fc0be08348ddc"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3145,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+dependencies = [
+ "bitflags 2.4.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,6 +3261,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -4149,6 +4243,16 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+dependencies = [
+ "getrandom 0.2.11",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "vcpkg"

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -28,6 +28,11 @@ tokio = { version = "1.33.0", features = ["fs"] }
 tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 serde_json = "1.0.105"
+dirs = "3.0"
+r2d2 = "0.8"
+r2d2_sqlite = "0.22"
+rusqlite = "0.29"
+load_file="1.0.1"
 
 [[bin]]
 name = "jstz-node"

--- a/crates/jstz_node/src/services/logs/create_db.sql
+++ b/crates/jstz_node/src/services/logs/create_db.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS request (
+    id TEXT NOT NULL PRIMARY KEY,
+    function_address TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS log (
+    id INTEGER PRIMARY KEY,
+    level TEXT,
+    content TEXT,
+    function_address TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+        FOREIGN KEY (request_id) REFERENCES request (id)
+);

--- a/crates/jstz_node/src/services/logs/db.rs
+++ b/crates/jstz_node/src/services/logs/db.rs
@@ -1,0 +1,83 @@
+use super::Line;
+use actix_web::web::block;
+use anyhow::{anyhow, Result};
+use jstz_proto::{js_logger::LogRecord, request_logger::RequestEvent};
+use load_file::load_str;
+use r2d2::{Pool, PooledConnection};
+use r2d2_sqlite::SqliteConnectionManager;
+use std::path::Path;
+pub type SqliteConnectionPool = r2d2::Pool<SqliteConnectionManager>;
+pub type SqliteConnection = r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>;
+
+pub struct DB {
+    pool: SqliteConnectionPool,
+}
+
+impl DB {
+    // Initialize the sql databse by createing a connection pool.
+    // if the database does not exist, it will be created.
+    pub async fn init<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let manager = SqliteConnectionManager::file(path);
+        let pool = SqliteConnectionPool::new(manager)?;
+
+        Self::create(pool.clone()).await?;
+
+        Ok(DB { pool })
+    }
+
+    async fn create(pool: Pool<SqliteConnectionManager>) -> Result<()> {
+        let connection: PooledConnection<SqliteConnectionManager> =
+            Self::connection(pool).await?;
+
+        connection
+            .execute_batch(load_str!("./create_db.sql"))
+            .map_err(|e| anyhow!("Failed to execute create_db.sql: {}", e.to_string()))
+    }
+
+    async fn connection(pool: SqliteConnectionPool) -> Result<SqliteConnection> {
+        block(move || pool.get())
+            .await
+            .map_err(|e| {
+                anyhow!("Failed to get connection from pool: {}", e.to_string())
+            })?
+            .map_err(|e| anyhow!("Failed to get connection from pool: {}", e.to_string()))
+    }
+
+    pub fn pool(&self) -> SqliteConnectionPool {
+        self.pool.clone()
+    }
+
+    // On success, returns the number of rows that were changed/inserted.
+    pub(super) async fn flush(&self, line: &Line) -> Result<usize> {
+        let pool = self.pool();
+
+        let connection: PooledConnection<SqliteConnectionManager> =
+            Self::connection(pool).await?;
+
+        match line {
+            Line::Request(RequestEvent::Start {
+                request_id,
+                contract_address,
+            }) => connection.execute(
+                "INSERT INTO request (id, function_address) VALUES (?1, ?2)",
+                (request_id, contract_address.to_string()),
+            ).map_err(|e| anyhow!("Failed to insert to db: {}", e.to_string())),
+            Line::Js(LogRecord {
+                request_id,
+                contract_address,
+                level,
+                text,
+            }) => connection.execute(
+                "INSERT INTO log (level, content, function_address, request_id) VALUES (?1, ?2, ?3, ?4)",
+                (
+                    level.to_string(),
+                    text,
+                    contract_address.to_string(),
+                    request_id
+                ),
+            ).map_err(|e| anyhow!("Failed to insert to db: {}", e.to_string())),
+            // TODO: Update the request row with more fields.
+            _ => Ok(0),
+        }
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,8 @@
 
                 python311Packages.base58
                 jq
+
+                sqlite
               ]
               ++ lib.optionals stdenv.isLinux [pkg-config openssl.dev];
           };


### PR DESCRIPTION
# Context

[Configure sql](https://app.asana.com/0/1205770721173531/1206350698277905/f) 

This is the second step of the persistent logs feature as shown below: 
 
1. add request logs 
Before we store sf logs in the DB, we need to add logs indicating the start and end of smart function request. #325 

2. define a sqlite schma, add a functionality to flush the logs to DB 

3. Store the logs from kernel.log to the DB, add new endpoints to jstz node to enable fetching logs  #329



# Description

This PR defines the schema to store the requests as well as the logs from kernel.log. The DB struct is used in the next PR (#329) to store the logs


# Manually testing the PR

Check: #329
