### PR TITLE
Cli: Remove `jstz_path` from CLI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,23 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v5
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
-      - name: Rust setup
-        run: rustup show active-toolchain
-
-      - name: Lint with Clippy
-        run: make lint
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+      - uses: Swatinem/rust-cache@v2.7.1
       - name: Rust setup
         run: rustup show active-toolchain
 
@@ -48,25 +38,29 @@ jobs:
       - name: Format (Nix)
         run: make fmt-nix-check
 
-  build:
+  build-rust:
     name: Build (Cargo)
     runs-on: ubuntu-latest
-    needs: [lint, fmt]
+    needs: [commitlint, fmt]
     steps:
       - uses: actions/checkout@v4
-
       - uses: Swatinem/rust-cache@v2.7.1
-
       - name: Rust setup
         run: rustup show active-toolchain
 
-      - name: Build
+      - name: Build kernel
+        run: make build-kernel
+
+      - name: Lint
+        run: make lint
+
+      - name: Build all packages
         run: cargo build
 
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest
-    needs: [lint, fmt]
+    needs: [commitlint, fmt]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -94,7 +88,7 @@ jobs:
   build-sdk:
     name: Build TypeScript SDK
     runs-on: ubuntu-latest
-    needs: [lint, fmt]
+    needs: [commitlint, fmt]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -122,7 +116,7 @@ jobs:
   build-nix:
     name: Build (Nix)
     runs-on: ubuntu-latest
-    needs: [build, build-sdk, build-docs]
+    needs: [build-rust, build-sdk, build-docs]
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v24
@@ -139,16 +133,10 @@ jobs:
       - name: Build
         run: nix build -j auto
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: kernel
-          path: result/lib/jstz_kernel.wasm
-
   build-docker:
     name: Build (Docker)
     runs-on: ubuntu-latest
-    needs: [build, build-sdk, build-docs]
+    needs: [build-rust, build-sdk, build-docs]
     outputs:
       jstz-rollup: ${{ steps.tags.outputs.tag || '' }}
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ node_modules/
 /.direnv
 
 .env
+
+# Required by the CLI
+crates/jstz_cli/jstz_kernel.wasm

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,26 @@
 .PHONY: all
-all: build test check
+all: test build check
+
+.PHONY: build
+build: build-cli-kernel
+	@cargo build --release
 
 .PHONY: build-bridge
 build-bridge:
 	@ligo compile contract contracts/jstz_bridge.mligo \
 		--module "Jstz_bridge" > contracts/jstz_bridge.tz
 
-.PHONY: build
-build:
+.PHONY: build-kernel
+build-kernel:
 	@cargo build --package jstz_kernel --target wasm32-unknown-unknown --release
+
+.PHONY: build-cli-kernel
+build-cli-kernel: build-kernel
+	@cp target/wasm32-unknown-unknown/release/jstz_kernel.wasm crates/jstz_cli/jstz_kernel.wasm
+
+.PHONY: build-cli
+build-cli: build-cli-kernel
+	@cargo build --package jstz_cli --release
 
 .PHONY: build-deps
 build-deps:
@@ -28,8 +40,8 @@ check: lint fmt
 .PHONY: clean
 clean:
 	@cargo clean
-	rm -f result
-	rm -rf logs
+	@rm -f result
+	@rm -rf logs
 
 .PHONY: fmt-nix-check
 fmt-nix-check:
@@ -61,6 +73,9 @@ fmt: fmt-nix fmt-rust fmt-js
 .PHONY: fmt-check
 fmt-check: fmt-nix-check fmt-rust-check fmt-js-check
 
+# FIXME: 
+# Clippy builds the CLI since the CLI must expand the macro containing the bytes of the `jstz_kernel.wasm` file. 
+# So in order to lint the CLI we need to build the kernel
 .PHONY: lint
-lint:
-	@cargo clippy -- -D warnings -A clippy::let_underscore_future -A clippy::module_inception -A clippy::op_ref -A clippy::manual_strip -A clippy::missing_safety_doc -A clippy::slow_vector_initialization -A clippy::empty_loop -A clippy::expect-fun-call
+lint: build-cli-kernel
+	@cargo clippy -- --no-deps -D warnings -A clippy::let_underscore_future -A clippy::module_inception -A clippy::op_ref -A clippy::manual_strip -A clippy::missing_safety_doc -A clippy::slow_vector_initialization -A clippy::empty_loop -A clippy::expect-fun-call

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -4,6 +4,7 @@ authors.workspace = true
 version.workspace = true
 edition.workspace = true
 repository.workspace = true
+include = ["jstz_kernel.wasm", "sandbox-params.json", "sandbox.json"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,7 +22,7 @@ serde_json = "1.0"
 bs58 = "0.5"
 hex = "0.4"
 dirs = "3.0"
-nix = { version = "^0.27.1", features = [ "process", "signal" ] }
+nix = { version = "^0.27.1", features = ["process", "signal"] }
 http = "1.0.0"
 fs_extra = "1.2"
 anyhow = "1.0.75"
@@ -42,12 +43,11 @@ reqwest = { version = "0.11.22", features = ["json"] }
 tokio = { version = "1.33.0", features = ["full"] }
 derive_more = "0.99.17"
 url = "2.2.2"
-
 boa_gc = "0.17.0"
 reqwest-eventsource = "0.5.0"
 futures-util = "0.3.29"
 syntect = "4.6.0"
-crossterm = "0.22" 
+crossterm = "0.22"
 ansi_term = "0.12.1"
 
 [[bin]]

--- a/crates/jstz_cli/build.rs
+++ b/crates/jstz_cli/build.rs
@@ -1,0 +1,68 @@
+//! This build script is used to copy the:
+//!   - jstz_kernel.wasm
+//!   - sandbox-params.json
+//!   - sandbox.json
+//! files to the OUT_DIR directory.
+//! It also generates the sandbox_paths.rs file which contains the paths to the files in the OUT_DIR.
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+const JSTZ_KERNEL_PATH: &str = "./jstz_kernel.wasm";
+
+const SANDBOX_PARAMS_PATH: &str = "./sandbox-params.json";
+
+const SANDBOX_PATH: &str = "./sandbox.json";
+
+fn generate_path_getter_code(name: &str, path: &Path) -> String {
+    format!(
+        r#"
+        const {}_PATH: &str = "{}";
+        "#,
+        name,
+        path.to_str().expect("Invalid path")
+    )
+}
+
+fn generate_code(out_dir: &Path) {
+    let mut code = String::new();
+
+    code.push_str(&generate_path_getter_code(
+        "JSTZ_KERNEL",
+        &out_dir.join("jstz_kernel.wasm"),
+    ));
+    code.push_str(&generate_path_getter_code(
+        "SANDBOX_PARAMS",
+        &out_dir.join("sandbox-params.json"),
+    ));
+    code.push_str(&generate_path_getter_code(
+        "SANDBOX",
+        &out_dir.join("sandbox.json"),
+    ));
+
+    fs::write(out_dir.join("sandbox_paths.rs"), code).expect("Failed to write paths.rs");
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed={}", JSTZ_KERNEL_PATH);
+    println!("cargo:rerun-if-changed={}", SANDBOX_PARAMS_PATH);
+    println!("cargo:rerun-if-changed={}", SANDBOX_PATH);
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    // Build jstz_kernel.wasm
+    fs::copy(JSTZ_KERNEL_PATH, out_dir.join("jstz_kernel.wasm"))
+        .expect("Failed to copy jstz_kernel.wasm to OUT_DIR");
+
+    // Copy sandbox-params.json to out_dir
+    fs::copy(SANDBOX_PARAMS_PATH, out_dir.join("sandbox-params.json"))
+        .expect("Failed to copy sandbox-params.json to OUT_DIR");
+
+    // Copy sandbox.json to out_dir
+    fs::copy(SANDBOX_PATH, out_dir.join("sandbox.json"))
+        .expect("Failed to copy sandbox.json to OUT_DIR");
+
+    generate_code(&out_dir);
+}

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -118,8 +118,6 @@ impl AccountConfig {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Config {
-    /// Path to `jstz` directory
-    pub jstz_path: PathBuf,
     /// Path to octez installation
     pub octez_path: PathBuf,
     /// Sandbox config (None if sandbox is not running)


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Removing dependence on jstz source location in CLI](https://app.asana.com/0/1205770721173531/1206345416248634/f)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->

This PR introduces a Rust build script that removes the need for `jstz_path` in the CLI.

This introduces an inadvertent semantic changes -- the `/logs` directory used by jstz CLI will be created in the current working directory:
- if you run `cargo run --bin jstz` in the root directory for the jstz repository, this should have no effect, but 
- if you run `cargo run --bin jstz` in a subdirectory `A`, this will create `A/logs` directory

In future, the `logs` directory will be in `/tmp` once we start the `jstz-node` automatically when running `jstz sandbox start`. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Running the sandbox and checking various features still work
