### PR TITLE
feat(cli): separate errors into 'user errors' and 'internal errors'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -787,6 +787,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1157,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1929,6 +1948,7 @@ dependencies = [
  "boa_gc",
  "bs58",
  "clap",
+ "console",
  "crossterm",
  "daemonize",
  "derive_more",

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -49,6 +49,7 @@ futures-util = "0.3.29"
 syntect = "4.6.0"
 crossterm = "0.22"
 ansi_term = "0.12.1"
+console = "0.15.8"
 
 [[bin]]
 name = "jstz"

--- a/crates/jstz_cli/src/account/account.rs
+++ b/crates/jstz_cli/src/account/account.rs
@@ -1,11 +1,11 @@
-use anyhow::anyhow;
-use anyhow::Result;
 use derive_more::From;
 use jstz_crypto::{
     keypair_from_passphrase, public_key::PublicKey, public_key_hash::PublicKeyHash,
     secret_key::SecretKey,
 };
 use serde::{Deserialize, Serialize};
+
+use crate::error::{bail, Result};
 
 // Represents an individual account
 #[derive(Serialize, Deserialize, Debug, Clone, From)]
@@ -69,17 +69,10 @@ impl Account {
         }
     }
 
-    pub fn as_owned_mut(&mut self) -> Result<&mut OwnedAccount> {
-        match self {
-            Account::Owned(owned_account) => Ok(owned_account),
-            Account::Alias(_) => Err(anyhow!("Account is not owned")),
-        }
-    }
-
     pub fn as_owned(&self) -> Result<&OwnedAccount> {
         match self {
             Account::Owned(owned_account) => Ok(owned_account),
-            Account::Alias(_) => Err(anyhow!("Account is not owned")),
+            Account::Alias(_) => bail!("Account is not owned."),
         }
     }
 }

--- a/crates/jstz_cli/src/bridge/deposit.rs
+++ b/crates/jstz_cli/src/bridge/deposit.rs
@@ -1,6 +1,4 @@
-use anyhow::Result;
-
-use crate::config::Config;
+use crate::{config::Config, error::Result};
 
 pub fn exec(from: String, to: String, amount: u64, cfg: &Config) -> Result<()> {
     // 1. Convert tz1 address to hexencoded bytes

--- a/crates/jstz_cli/src/bridge/mod.rs
+++ b/crates/jstz_cli/src/bridge/mod.rs
@@ -1,9 +1,8 @@
-use anyhow::Result;
 use clap::Subcommand;
 
 mod deposit;
 
-use crate::config::Config;
+use crate::{config::Config, error::Result};
 
 #[derive(Subcommand)]
 pub enum Command {

--- a/crates/jstz_cli/src/error.rs
+++ b/crates/jstz_cli/src/error.rs
@@ -1,0 +1,57 @@
+use std::fmt::{self, Debug};
+
+use crate::term::styles::url;
+
+#[derive(Debug)]
+pub struct UserError {
+    pub message: String,
+}
+
+impl fmt::Display for UserError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for UserError {}
+
+pub type Error = anyhow::Error;
+
+pub fn print(err: &Error) {
+    if let Some(user_error) = err.downcast_ref::<UserError>() {
+        eprintln!("{}", user_error);
+    } else {
+        eprintln!(
+            "{}\n\nIf you think this is a bug then please create an issue at {}.",
+            err,
+            url("https://github.com/trilitech/jstz/issues/new/choose")
+        );
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+macro_rules! user_error {
+    ($msg:literal $(,)?) => {
+        anyhow::anyhow!($crate::error::UserError {
+            message: format!($msg),
+        })
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        anyhow::anyhow!($crate::error::UserError {
+            message: format!($fmt, $($arg)*)
+        })
+    };
+}
+
+macro_rules! bail_user_error {
+    ($msg:literal $(,)?) => {
+        return Err($crate::error::user_error!($msg))
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        return Err($crate::error::user_error!($fmt, $($arg)*))
+    };
+}
+
+pub(crate) use anyhow::{anyhow, bail};
+pub(crate) use {bail_user_error, user_error};

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -1,10 +1,12 @@
 use std::time::Duration;
 
-use anyhow::anyhow;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use jstz_api::KvValue;
-use jstz_proto::operation::SignedOperation;
-use jstz_proto::{context::account::Nonce, operation::OperationHash, receipt::Receipt};
+use jstz_proto::{
+    context::account::Nonce,
+    operation::{OperationHash, SignedOperation},
+    receipt::Receipt,
+};
 use reqwest::StatusCode;
 use tokio::time::sleep;
 
@@ -54,7 +56,7 @@ impl JstzClient {
             }
             StatusCode::NOT_FOUND => Ok(Nonce::default()),
             // For any other status, return a generic error
-            _ => Err(anyhow!("Failed to get nonce")),
+            _ => bail!("Failed to get nonce"),
         }
     }
 
@@ -69,7 +71,7 @@ impl JstzClient {
                 Ok(code)
             }
             // For any other status, return a generic error
-            _ => Err(anyhow!("Failed to get the code")),
+            _ => bail!("Failed to get the code"),
         }
     }
 
@@ -83,7 +85,7 @@ impl JstzClient {
                 let balance = response.json::<u64>().await?;
                 Ok(balance)
             }
-            _ => Err(anyhow!("Failed to get the balance")),
+            _ => bail!("Failed to get the balance"),
         }
     }
 
@@ -102,7 +104,7 @@ impl JstzClient {
             }
             StatusCode::NOT_FOUND => Ok(None),
             // For any other status, return a generic error
-            _ => Err(anyhow!("Failed to get value.")),
+            _ => bail!("Failed to get value."),
         }
     }
 
@@ -127,7 +129,7 @@ impl JstzClient {
                 Ok(Some(kv))
             }
             StatusCode::NOT_FOUND => Ok(None),
-            _ => Err(anyhow!("Failed to get subkey list.")),
+            _ => bail!("Failed to get subkey list."),
         }
     }
 
@@ -156,7 +158,7 @@ impl JstzClient {
         match response.status() {
             StatusCode::OK => Ok(()),
             // For any other status, return a generic error
-            _ => Err(anyhow!("Failed to post operation")),
+            _ => bail!("Failed to post operation"),
         }
     }
 

--- a/crates/jstz_cli/src/kv.rs
+++ b/crates/jstz_cli/src/kv.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
 use clap::Subcommand;
 
-use crate::config::Config;
+use crate::{config::Config, error::Result};
 
 async fn get(alias: Option<String>, key: String, cfg: &mut Config) -> Result<()> {
     let jstz_client = cfg.jstz_client()?;

--- a/crates/jstz_cli/src/logs/mod.rs
+++ b/crates/jstz_cli/src/logs/mod.rs
@@ -1,8 +1,7 @@
-use anyhow::Result;
 use clap::Subcommand;
 use jstz_api::js_log::LogLevel;
 
-use crate::config::Config;
+use crate::{config::Config, Result};
 
 mod trace;
 

--- a/crates/jstz_cli/src/logs/trace.rs
+++ b/crates/jstz_cli/src/logs/trace.rs
@@ -1,9 +1,9 @@
-use crate::Config;
-use anyhow::Result;
 use futures_util::stream::StreamExt;
 use jstz_api::js_log::LogLevel;
 use jstz_proto::js_logger::LogRecord;
 use reqwest_eventsource::{Event, EventSource};
+
+use crate::{error::Result, Config};
 
 const DEFAULT_LOG_LOG_LEVEL: LogLevel = LogLevel::LOG;
 
@@ -24,7 +24,7 @@ pub async fn exec(
 
     while let Some(event) = event_source.next().await {
         match event {
-            Ok(Event::Open) => println!("Connection open with {}", url),
+            Ok(Event::Open) => println!("Event source opened."),
             Ok(Event::Message(message)) => {
                 if let Ok(log_record) = serde_json::from_str::<LogRecord>(&message.data) {
                     let LogRecord { level, text, .. } = log_record;
@@ -34,8 +34,8 @@ pub async fn exec(
                 }
             }
             Err(err) => {
-                println!("Event source error: {}", err);
                 event_source.close();
+                eprintln!("Event source closed with an error: {}", err);
             }
         }
     }

--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -7,7 +7,6 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Result;
 use jstz_rollup::{
     deploy_ctez_contract, rollup::make_installer, BootstrapAccount, BridgeContract,
     JstzRollup,
@@ -15,7 +14,10 @@ use jstz_rollup::{
 use octez::OctezThread;
 use tempfile::TempDir;
 
-use crate::config::{Config, SandboxConfig, SANDBOX_OCTEZ_SMART_ROLLUP_PORT};
+use crate::{
+    config::{Config, SandboxConfig, SANDBOX_OCTEZ_SMART_ROLLUP_PORT},
+    error::{bail_user_error, Result},
+};
 
 include!(concat!(env!("OUT_DIR"), "/sandbox_paths.rs"));
 
@@ -228,7 +230,7 @@ fn start_sandbox(cfg: &Config) -> Result<(OctezThread, OctezThread, OctezThread)
 pub fn main(cfg: &mut Config) -> Result<()> {
     // 1. Check if sandbox is already running
     if cfg.sandbox.is_some() {
-        return Err(anyhow::anyhow!("Sandbox is already running!"));
+        bail_user_error!("The sandbox is already running!");
     }
 
     // 1. Configure sandbox

--- a/crates/jstz_cli/src/sandbox/mod.rs
+++ b/crates/jstz_cli/src/sandbox/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use nix::{
     sys::signal::{kill, Signal},
@@ -7,7 +6,10 @@ use nix::{
 
 mod daemon;
 
-use crate::config::Config;
+use crate::{
+    config::Config,
+    error::{bail_user_error, Result},
+};
 
 #[derive(Subcommand)]
 pub enum Command {
@@ -34,7 +36,7 @@ pub fn stop(cfg: &mut Config) -> Result<()> {
             kill(pid, Signal::SIGTERM)?;
             Ok(())
         }
-        None => Err(anyhow!("Sandbox is not running!")),
+        None => bail_user_error!("The sandbox is not running!"),
     }
 }
 

--- a/crates/jstz_cli/src/term/emoji.rs
+++ b/crates/jstz_cli/src/term/emoji.rs
@@ -1,0 +1,4 @@
+use console::Emoji;
+
+pub static WARN: Emoji = Emoji("▲", "");
+pub static ERROR: Emoji = Emoji("✕", "");

--- a/crates/jstz_cli/src/term/mod.rs
+++ b/crates/jstz_cli/src/term/mod.rs
@@ -1,0 +1,2 @@
+pub mod emoji;
+pub mod styles;

--- a/crates/jstz_cli/src/term/styles.rs
+++ b/crates/jstz_cli/src/term/styles.rs
@@ -1,0 +1,35 @@
+use std::fmt::{self, Display};
+
+use console::{style, StyledObject};
+
+use crate::term::emoji;
+
+pub struct ErrorPrefix;
+
+impl Display for ErrorPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {}",
+            style(emoji::ERROR).red(),
+            style(" ERROR ").on_red().white(),
+        )
+    }
+}
+
+pub struct WarningPrefix;
+
+impl Display for WarningPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {}",
+            style(emoji::WARN).yellow(),
+            style(" WARNING ").black().on_yellow(),
+        )
+    }
+}
+
+pub fn url<D>(msg: D) -> StyledObject<D> {
+    style(msg).blue().bold()
+}


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

Improves CLI error reporting

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR:
1. Introduces an `error.rs` file that defines the CLI's result + error type (anyhow w/ internal constructors such as `UserError`).
2. Updates the rest of the CLI to use this error module.
3. Improves various error messages in the CLI


# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Running a selection of commands with erroneous outputs
