### PR TITLE
feat(cli): use `dialoguer` for interactive prompts (`login` & `delete`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2035,7 @@ dependencies = [
  "crossterm",
  "daemonize",
  "derive_more",
+ "dialoguer",
  "dirs",
  "env_logger 0.11.1",
  "fs_extra",
@@ -3466,6 +3480,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook"

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -54,6 +54,7 @@ console = "0.15.8"
 futures = "0.3"
 env_logger = "0.11.1"
 log = "0.4.20"
+dialoguer = "0.11.0"
 
 [[bin]]
 name = "jstz"

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -108,6 +108,10 @@ impl AccountConfig {
         self.accounts.insert(alias, account.into());
     }
 
+    pub fn entry(&mut self, alias: String) -> hash_map::Entry<String, Account> {
+        self.accounts.entry(alias)
+    }
+
     pub fn get(&self, alias: &str) -> Option<&Account> {
         self.accounts.get(alias)
     }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
 **Dependencies**: #364 

This PR improves our current interactive prompts (for the account commands) by:
- Using a standardized library (dialoguer)
- Adds functionality to the prompts (account generation for `login`)

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->