### PR TITLE
fix(node): Allow JSON `SignedOperations` for `POST /operations`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,6 @@ version = "0.1.0"
 dependencies = [
  "ansi_term",
  "anyhow",
- "bincode",
  "boa_engine",
  "boa_gc",
  "bs58",

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -38,7 +38,6 @@ tezos_crypto_rs.workspace = true
 sha2 = "0.10"
 rand = "0.8"
 tiny-bip39 = "1.0.0"
-bincode = "1.3.3"
 reqwest = { version = "0.11.22", features = ["json"] }
 tokio = { version = "1.33.0", features = ["full"] }
 derive_more = "0.99.17"

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -149,7 +149,7 @@ impl JstzClient {
         let response = self
             .client
             .post(&format!("{}/operations", self.endpoint))
-            .body(bincode::serialize(operation)?)
+            .json(operation)
             .send()
             .await?;
 


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR fixes a known issue about `jstz-node` -- namely that `POST /operations` accepts bytes as opposed to a `SignedOperation`. 

This was due to an issue with the serializer and deserializer for `SignedOperation` while it was using tz4 addresses (from `tezos_crypto_rs`). Following #352, we now use tz1 addresses (which have a working serializer & deserializer 😊). 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

With the sandbox + jstz node running:
```sh
cargo run --bin jstz -- deploy examples/counter.js
```

Inspect the jstz-node logs for a `POST /operations` call. 

