### PR TITLE
ci(commitlint): extend `body-max-line-length` to 200

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,7 @@
-module.exports = { extends: ["@commitlint/config-conventional"] };
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    // Ensure the body does not exceed 200 characters (default of config-conventional is 100)
+    "body-max-line-length": [2, "always", 200],
+  },
+};


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

A lot of our dependabot PR's don't pass our CI due to our commitlint rules -- namely most of the commit msg bodies exceed 100 characters per a line (primarily due to the inclusion of links in the commit msg). 

This PR extends the limit to 200 characters, which should be sufficient. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
