### PR TITLE
feat(cli): add `completions` command to jstz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb745187d7f4d76267b37485a65e0149edd0e91a4cfcdd3f27524ad86cee9f3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2114,7 @@ dependencies = [
  "boa_gc",
  "bs58",
  "clap",
+ "clap_complete",
  "console",
  "crossterm",
  "daemonize",

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -56,6 +56,7 @@ log = "0.4.20"
 dialoguer = "0.11.0"
 prettytable = "0.10.0"
 serde_with = { version = "3.6.1", features = ["macros"] }
+clap_complete = "4.4.10"
 
 [[bin]]
 name = "jstz"

--- a/crates/jstz_cli/src/completions.rs
+++ b/crates/jstz_cli/src/completions.rs
@@ -1,0 +1,12 @@
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::Shell;
+
+use crate::{error::Result, Command};
+
+pub fn exec(shell: Shell) -> Result<()> {
+    let cmd = &mut Command::command();
+    clap_complete::generate(shell, cmd, "jstz", &mut io::stdout());
+    Ok(())
+}

--- a/crates/jstz_cli/src/main.rs
+++ b/crates/jstz_cli/src/main.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
+use clap_complete::Shell;
 
 mod account;
 mod bridge;
+mod completions;
 mod config;
 mod deploy;
 mod docs;
@@ -38,6 +40,12 @@ enum Command {
     /// 🔑 Interact with jstz's key-value store.
     #[command(subcommand)]
     Kv(kv::Command),
+    /// 🐚 Generates shell completions.
+    Completions {
+        /// The shell to generate completions for
+        #[arg(long, short)]
+        shell: Shell,
+    },
     /// 🚀 Deploys a smart function to jstz.
     Deploy {
         /// Function code.
@@ -98,6 +106,7 @@ enum Command {
 async fn exec(command: Command) -> Result<()> {
     match command {
         Command::Docs => docs::exec(),
+        Command::Completions { shell } => completions::exec(shell),
         Command::Sandbox(sandbox_command) => sandbox::exec(sandbox_command).await,
         Command::Bridge(bridge_command) => bridge::exec(bridge_command),
         Command::Account(account_command) => account::exec(account_command).await,


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Shell autocompletions for CLI](https://app.asana.com/0/1205770721173531/1206472793750873/f)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR adds a `completions` command to `jstz`, which prints the autocompletions for the CLI to stdout

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Since we don't yet globally install jstz as a binary, it's a bit finicky to test locally. 

For zsh:
```sh
autoload -U compinit && compinit
source <(cargo run --bin jstz -- completions --shell=zsh)
compdef _jstz ./target/debug/jstz
```

To use the completions, you must use `./target/debug/jstz [Tab]` ([Tab] denotes you pressing tab). I've not been able to get this to work with `cargo run --bin jstz -- ...`

For other shells:
https://github.com/clap-rs/clap/issues/2488#issuecomment-864576617
