### PR TITLE
Node: fix running the server in main

### DIFF
--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -260,6 +260,9 @@ fn client_bake(cfg: &Config, log_file: &File) -> Result<()> {
     Ok(())
 }
 
+/// Since actix_web uses a single-threaded runtime,
+/// the tasks spawned by `jstz_node` expect to run on the same thread.
+/// For more information, see: https://docs.rs/actix-rt/latest/actix_rt/
 async fn run_jstz_node() -> Result<()> {
     let local = task::LocalSet::new();
 

--- a/crates/jstz_node/src/main.rs
+++ b/crates/jstz_node/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     kernel_log_path: PathBuf,
 }
 
-#[tokio::main]
+#[actix_web::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init_from_env(Env::default().default_filter_or("info"));
 


### PR DESCRIPTION
# Context
Executing the jstz_node binary outside of sandbox environment leads to a panic. This problem arises when spawning the broadcaster future that expects to be called inside the `LocalSet`, a set of task executed on the same thread.


# Description
This PR fixes the issue by replacing the tokio's runtime with the #[actix_web::main].

# Manually testing the PR

run the jstz_node binary as well as the sandbox to see if it works.
