### PR TITLE
feat(core,proto,kernel,cli): nested transactions

### DIFF
--- a/crates/jstz_api/src/js_log.rs
+++ b/crates/jstz_api/src/js_log.rs
@@ -50,6 +50,7 @@ thread_local! {
     /// Thread-local logger
     static CONSOLE_LOGGER: Cell<Option<&'static dyn JsLog>> = Cell::new(None)
 }
+
 pub fn set_js_logger(logger: &'static dyn JsLog) {
     CONSOLE_LOGGER.set(Some(logger));
 }

--- a/crates/jstz_cli/src/repl/debug_api/account.rs
+++ b/crates/jstz_cli/src/repl/debug_api/account.rs
@@ -4,18 +4,9 @@ use boa_engine::{
     js_string, object::ObjectInitializer, Context, JsArgs, JsNativeError, JsObject,
     JsResult, JsValue, NativeFunction,
 };
-use jstz_core::{host_defined, kv::Transaction, runtime};
+use jstz_core::runtime;
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_proto::context::account::Account;
-
-macro_rules! preamble {
-    ($args:ident, $context:ident, $tx:ident) => {
-        host_defined!($context, host_defined);
-        let mut $tx = host_defined
-            .get_mut::<Transaction>()
-            .expect("Curent transaction undefined");
-    };
-}
 
 fn get_public_key_hash(account: &str) -> JsResult<PublicKeyHash> {
     PublicKeyHash::from_base58(account).map_err(|_| {
@@ -33,14 +24,13 @@ impl AccountApi {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        preamble!(args, context, tx);
-
         let account: String = args.get_or_undefined(0).try_js_into(context)?;
 
         let pkh = get_public_key_hash(account.as_str())?;
 
-        let result =
-            runtime::with_global_host(|rt| Account::balance(rt.deref(), &mut tx, &pkh))?;
+        let result = runtime::with_js_hrt_and_tx(|hrt, tx| {
+            Account::balance(hrt.deref(), tx, &pkh)
+        })?;
 
         Ok(JsValue::from(result))
     }
@@ -50,16 +40,14 @@ impl AccountApi {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        preamble!(args, context, tx);
-
         let account: String = args.get_or_undefined(0).try_js_into(context)?;
 
         let balance: u64 = args.get_or_undefined(1).try_js_into(context)?;
 
         let pkh = get_public_key_hash(account.as_str())?;
 
-        runtime::with_global_host(|rt| {
-            Account::set_balance(rt.deref(), &mut tx, &pkh, balance)
+        runtime::with_js_hrt_and_tx(|hrt, tx| {
+            Account::set_balance(hrt.deref(), tx, &pkh, balance)
         })?;
         Ok(JsValue::undefined())
     }
@@ -69,20 +57,16 @@ impl AccountApi {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        preamble!(args, context, tx);
-
         let account: String = args.get_or_undefined(0).try_js_into(context)?;
 
         let pkh = get_public_key_hash(account.as_str())?;
 
-        let result = runtime::with_global_host(|rt| {
-            Account::contract_code(rt.deref(), &mut tx, &pkh)
-        })?;
-
-        match result {
-            Some(value) => Ok(JsValue::String(value.to_string().into())),
-            None => Ok(JsValue::null()),
-        }
+        runtime::with_js_hrt_and_tx(|hrt, tx| -> JsResult<JsValue> {
+            match Account::contract_code(hrt.deref(), tx, &pkh)? {
+                Some(value) => Ok(JsValue::String(value.to_string().into())),
+                None => Ok(JsValue::null()),
+            }
+        })
     }
 
     fn set_code(
@@ -90,15 +74,13 @@ impl AccountApi {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        preamble!(args, context, tx);
-
         let account: String = args.get_or_undefined(0).try_js_into(context)?;
         let code: String = args.get_or_undefined(1).try_js_into(context)?;
 
         let pkh = get_public_key_hash(account.as_str())?;
 
-        runtime::with_global_host(|rt| {
-            Account::set_contract_code(rt.deref(), &mut tx, &pkh, code)
+        runtime::with_js_hrt_and_tx(|hrt, tx| {
+            Account::set_contract_code(hrt.deref(), tx, &pkh, code)
         })?;
 
         Ok(JsValue::undefined())

--- a/crates/jstz_cli/src/repl/js_logger.rs
+++ b/crates/jstz_cli/src/repl/js_logger.rs
@@ -1,6 +1,6 @@
 use boa_engine::Context;
 use jstz_api::js_log::{JsLog, LogData};
-use jstz_core::runtime::with_global_host;
+use jstz_core::runtime;
 use tezos_smart_rollup::prelude::debug_msg;
 
 pub(crate) struct PrettyLogger;
@@ -15,9 +15,10 @@ impl JsLog for PrettyLogger {
 
         let indent = 2 * groups_len;
         let symbol = level.symbol();
-        with_global_host(|rt| {
+
+        runtime::with_js_hrt(|hrt| {
             for line in text.lines() {
-                debug_msg!(rt, "[{symbol}] {:>indent$}{line}\n", "");
+                debug_msg!(hrt, "[{symbol}] {:>indent$}{line}\n", "");
             }
         });
     }

--- a/crates/jstz_core/src/error.rs
+++ b/crates/jstz_core/src/error.rs
@@ -2,7 +2,17 @@ use boa_engine::{JsError, JsNativeError};
 use derive_more::{Display, Error, From};
 
 #[derive(Display, Debug, Error, From)]
+pub enum KvError {
+    DowncastFailed,
+    TransactionStackEmpty,
+    ExpectedLookupMapEntry,
+}
+
+#[derive(Display, Debug, Error, From)]
 pub enum Error {
+    KvError {
+        source: KvError,
+    },
     HostError {
         source: crate::host::HostError,
     },
@@ -20,6 +30,9 @@ pub enum Error {
 impl From<Error> for JsError {
     fn from(value: Error) -> Self {
         match value {
+            Error::KvError { source } => JsNativeError::eval()
+                .with_message(format!("KvError: {}", source))
+                .into(),
             Error::HostError { source } => JsNativeError::eval()
                 .with_message(format!("HostError: {}", source))
                 .into(),

--- a/crates/jstz_core/src/kv/mod.rs
+++ b/crates/jstz_core/src/kv/mod.rs
@@ -12,7 +12,7 @@ use crate::error::Result;
 pub mod transaction;
 pub mod value;
 
-pub use transaction::{Entry, Transaction};
+pub use transaction::{Entry, JsTransaction, Transaction};
 pub use value::Value;
 
 /// A transactional key-value store using an optimistic concurrency control scheme.

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -1,5 +1,5 @@
 use jstz_core::kv::{Storage, Transaction};
-use jstz_proto::{context::account::Account, executor, Result};
+use jstz_proto::{executor, Result};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     kernel_entry,
@@ -18,7 +18,8 @@ fn read_ticketer(rt: &impl Runtime) -> Option<ContractKt1Hash> {
 }
 
 fn handle_message(hrt: &mut (impl Runtime + 'static), message: Message) -> Result<()> {
-    let mut tx = Transaction::new();
+    let mut tx = Transaction::default();
+    tx.begin();
 
     match message {
         Message::Internal(external_operation) => {
@@ -32,7 +33,7 @@ fn handle_message(hrt: &mut (impl Runtime + 'static), message: Message) -> Resul
         }
     }
 
-    tx.commit::<Account>(hrt)?;
+    tx.commit(hrt)?;
     Ok(())
 }
 

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -196,8 +196,9 @@ mod test {
     #[test]
     fn test_zero_account_balance_for_new_accounts() -> Result<()> {
         let hrt = &mut MockHost::default();
+        let tx = &mut Transaction::default();
 
-        let tx = &mut Transaction::new();
+        tx.begin();
 
         let pkh = PublicKeyHash::from_base58("tz1XQjK1b3P72kMcHsoPhnAg3dvX1n8Ainty")
             .expect("Could not parse pkh");
@@ -209,7 +210,7 @@ mod test {
                 .amount
         };
         {
-            tx.commit::<Account>(hrt).expect("Could not commit tx");
+            tx.commit(hrt).expect("Could not commit tx");
         }
 
         // Assert

--- a/crates/jstz_proto/src/js_logger.rs
+++ b/crates/jstz_proto/src/js_logger.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use boa_engine::prelude::Context;
 pub use jstz_api::js_log::{JsLog, LogData, LogLevel};
-use jstz_core::{host::HostRuntime, host_defined, runtime::with_global_host};
+use jstz_core::{host::HostRuntime, host_defined, runtime};
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -59,8 +59,8 @@ pub(crate) struct JsonLogger;
 impl JsLog for JsonLogger {
     fn log(&self, log_data: LogData, context: &mut Context<'_>) {
         let log_record = LogRecord::new(log_data, context).to_string();
-        with_global_host(|rt| {
-            rt.write_debug(&(LOG_PREFIX.to_string() + &log_record + "\n"));
+        runtime::with_js_hrt(|hrt| {
+            hrt.write_debug(&(LOG_PREFIX.to_string() + &log_record + "\n"));
         });
     }
 }

--- a/crates/jstz_proto/src/request_logger.rs
+++ b/crates/jstz_proto/src/request_logger.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use jstz_core::{host::HostRuntime, runtime::with_global_host};
+use jstz_core::{host::HostRuntime, runtime};
 use serde::{Deserialize, Serialize};
 
 use crate::context::account::Address;
@@ -42,8 +42,9 @@ pub fn log_request_start(contract_address: Address, request_id: String) {
         request_id,
     }
     .to_string();
-    with_global_host(|rt| {
-        rt.write_debug(&(REQUEST_START_PREFIX.to_string() + &request_log + "\n"));
+
+    runtime::with_js_hrt(|hrt| {
+        hrt.write_debug(&(REQUEST_START_PREFIX.to_string() + &request_log + "\n"));
     });
 }
 
@@ -53,7 +54,8 @@ pub fn log_request_end(contract_address: Address, request_id: String) {
         request_id,
     }
     .to_string();
-    with_global_host(|rt| {
-        rt.write_debug(&(REQUEST_END_PREFIX.to_string() + &request_log + "\n"));
+
+    runtime::with_js_hrt(|hrt| {
+        hrt.write_debug(&(REQUEST_END_PREFIX.to_string() + &request_log + "\n"));
     });
 }

--- a/examples/nested_counter.js
+++ b/examples/nested_counter.js
@@ -1,0 +1,22 @@
+const KEY = "counter";
+
+const handler = async (request) => {
+  const url = new URL(request.url);
+  const incr = url.searchParams.get("incr");
+
+  let counter = Kv.get(KEY);
+  console.log(`Counter: ${counter}`);
+
+  counter = counter === null ? 0 : counter + 1;
+  Kv.set(KEY, counter);
+
+  if (incr !== null) {
+    console.log(`Nested transaction: ${incr}`);
+    // Nested transaction
+    await fetch(new Request(`tezos://${incr}/`));
+  }
+
+  return new Response();
+};
+
+export default handler;

--- a/examples/nested_transactions.js
+++ b/examples/nested_transactions.js
@@ -4,7 +4,12 @@ async function handler() {
 
       let counter = Kv.get("Counter3");
       console.log("Counter 3: " + counter);
-      Kv.set("Counter3", counter+1);
+      if (counter === null) {
+        counter = 0;
+      } else {
+        counter++;
+      }
+      Kv.set("Counter3", counter);
       console.log("Hello World");
       const arg = request.text();
       console.log(arg);
@@ -30,7 +35,12 @@ async function handler() {
       );
       let counter = Kv.get("Counter2");
       console.log("Counter 2: " + counter);
-      Kv.set("Counter2", counter+1);
+      if (counter === null) {
+        counter = 0;
+      } else {
+        counter++;
+      }
+      Kv.set("Counter2", counter);
       const arg = request.text();
       console.log(arg);
       return new Response();
@@ -49,6 +59,7 @@ async function handler() {
 
   let counter = Kv.get("Counter1");
   console.log(`Counter 1: ${counter}`);
+
   if (counter === null) {
     counter = 0;
   } else {


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Support nested transactions in `jstz_proto`](https://app.asana.com/0/1205770721173531/1206345416213104/f) 

This PR adds the long awaited support for nested transactions in `jstz_proto`, permitting _atomic synchronous nested smart function calls_. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

Myself and @alanmarkoTrilitech discovered some issues with the old implementation of nested transactions -- namely the use of lifetimes caused issues if we used `Rc<RefCell<_>>` for a pointer to the parent transaction. 

There were two possible solutions to this:
- Wrapping all snapshot values in `Rc<RefCell<_>>`, thus eliminating most lifetimes from the transaction API
- Using the transactional stack design from https://www.notion.so/trilitech/Transactional-Storage-4c4a4b173145498dbbb61448e505ee16?pvs=4

This PR implements the latter. 

This PR contains:
- An entire rewrite of transactions to use the above design
- The integration of nested transactions with all JavaScript runtime APIs
- The integration of nested transactions with `jstz_proto` and `jstz_kernel`

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

To observe nested transactions:
```
cargo run --bin jstz -- deploy examples/nested_counter.js
```
Save the address `A`. Tail the function. 
Run
```
cargo run --bin jstz -- run "tezos://${A}/?incr=${A}"
```