### PR TITLE
feat: implemented `CountQueuingStrategy`

### DIFF
--- a/crates/jstz_api/src/stream/mod.rs
+++ b/crates/jstz_api/src/stream/mod.rs
@@ -1,14 +1,21 @@
 use boa_engine::Context;
 
-use self::readable::ReadableStreamApi;
+use crate::{
+    idl,
+    stream::{queuing_strategy::QueuingStrategyApi, readable::ReadableStreamApi},
+};
 
+pub mod queuing_strategy;
 pub mod readable;
 mod tmp;
+
+type Chunk = idl::Any;
 
 pub struct StreamApi;
 
 impl jstz_core::Api for StreamApi {
     fn init(self, context: &mut Context<'_>) {
         ReadableStreamApi.init(context);
+        QueuingStrategyApi.init(context);
     }
 }

--- a/crates/jstz_api/src/stream/queuing_strategy/builtin.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/builtin.rs
@@ -1,0 +1,216 @@
+use crate::{
+    idl,
+    stream::{
+        queuing_strategy::size::{
+            ByteLengthQueuingStrategySizeAlgorithm, CountQueuingStrategySizeAlgorithm,
+        },
+        tmp::get_jsobject_property,
+    },
+};
+use boa_engine::{
+    js_string, object::Object, property::Attribute, value::TryFromJs, Context, JsArgs,
+    JsNativeError, JsResult, JsValue, NativeFunction,
+};
+use boa_gc::{Finalize, GcRefMut, Trace};
+use jstz_core::{
+    accessor,
+    js_fn::JsCallableWithoutThis,
+    native::{Accessor, ClassBuilder, JsNativeObject, NativeClass},
+};
+
+/// [Streams Standard - § 7.1.][https://streams.spec.whatwg.org/#qs-api]
+/// > ```
+/// > dictionary QueuingStrategyInit {
+/// >   required unrestricted double highWaterMark;
+/// > };
+/// > ```
+pub struct QueuingStrategyInit {
+    pub high_water_mark: idl::UnrestrictedDouble,
+}
+
+impl TryFromJs for QueuingStrategyInit {
+    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+        let this = value.to_object(context)?;
+        let high_water_mark: idl::UnrestrictedDouble =
+            get_jsobject_property(&this, "highWaterMark", context)?
+                .try_js_into::<Option<idl::UnrestrictedDouble>>(context)?
+                .ok_or_else(|| {
+                    JsNativeError::typ()
+                        .with_message("Missing required highWaterMark property")
+                })?;
+        // TODO: .try_js_into::<Option<idl::UnrestrictedDouble>>(context) is slightly wrong. "arandomstring" should map to "NaN"
+        Ok(QueuingStrategyInit { high_water_mark })
+    }
+}
+
+/// Streams Standard - § 7.3. The CountQueuingStrategy class][https://streams.spec.whatwg.org/#cqs-class]
+/// > A common queuing strategy when dealing with streams of generic objects is to simply count the number of chunks that have been accumulated so far, waiting until this number reaches a specified high-water mark. As such, this strategy is also provided out of the box.
+///
+/// [Streams Standard - § 7.3.1.][https://streams.spec.whatwg.org/#countqueuingstrategy]
+/// > ```
+/// > [Exposed=*]
+/// > interface CountQueuingStrategy {
+/// >   constructor(QueuingStrategyInit init);
+/// >
+/// >   readonly attribute unrestricted double highWaterMark;
+/// >   readonly attribute Function size;
+/// > };
+/// > ```
+///
+#[derive(Trace, Finalize)]
+pub struct CountQueuingStrategy {
+    pub high_water_mark: idl::UnrestrictedDouble,
+}
+
+impl CountQueuingStrategy {
+    pub fn size_algorithm(&self) -> CountQueuingStrategySizeAlgorithm {
+        CountQueuingStrategySizeAlgorithm::ReturnOne
+    }
+}
+
+#[derive(Trace, Finalize)]
+pub struct ByteLengthQueuingStrategy {
+    pub high_water_mark: idl::UnrestrictedDouble,
+}
+
+impl ByteLengthQueuingStrategy {
+    pub fn size_algorithm(&self) -> ByteLengthQueuingStrategySizeAlgorithm {
+        ByteLengthQueuingStrategySizeAlgorithm::ReturnByteLengthOfChunk
+    }
+}
+
+macro_rules! impl_for_builtin_queuing_strategy_struct {
+    ($struct_name: ident, $struct_name_as_str: expr) => {
+        impl $struct_name {
+            pub fn new(init: QueuingStrategyInit) -> Self {
+                $struct_name {
+                    high_water_mark: init.high_water_mark,
+                }
+            }
+
+            pub fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<Object, Self>> {
+                value
+                    .as_object()
+                    .and_then(|obj| obj.downcast_mut::<Self>())
+                    .ok_or_else(|| {
+                        JsNativeError::typ()
+                            .with_message(format!(
+                                "Failed to convert js value into Rust type `{}`",
+                                $struct_name_as_str
+                            ))
+                            .into()
+                    })
+            }
+        }
+    };
+}
+
+impl_for_builtin_queuing_strategy_struct!(CountQueuingStrategy, "CountQueuingStrategy");
+impl_for_builtin_queuing_strategy_struct!(
+    ByteLengthQueuingStrategy,
+    "ByteLengthQueuingStrategy"
+);
+
+pub struct CountQueuingStrategyClass {}
+pub struct ByteLengthQueuingStrategyClass {}
+
+macro_rules! define_high_water_mark_accessor_for_builtin_queuing_strategy_class {
+    ($class_name : ident) => {
+        impl $class_name {
+            fn high_water_mark(context: &mut Context<'_>) -> Accessor {
+                accessor!(
+                    context,
+                    CountQueuingStrategy,
+                    "highWaterMark",
+                    get:((strategy, _context) => Ok(strategy.high_water_mark.into()))
+                )
+            }
+        }
+    }
+}
+
+define_high_water_mark_accessor_for_builtin_queuing_strategy_class!(
+    CountQueuingStrategyClass
+);
+define_high_water_mark_accessor_for_builtin_queuing_strategy_class!(
+    ByteLengthQueuingStrategyClass
+);
+
+impl CountQueuingStrategyClass {
+    fn size(
+        _this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
+        Ok(CountQueuingStrategySizeAlgorithm::RETURN_VALUE.into())
+    }
+}
+
+impl ByteLengthQueuingStrategyClass {
+    fn size(
+        _this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
+        let chunk = args.get_or_undefined(0);
+        ByteLengthQueuingStrategySizeAlgorithm::ReturnByteLengthOfChunk
+            .call_without_this((chunk.clone(),), context)
+            .map(Into::into)
+    }
+}
+
+macro_rules! define_builtin_queuing_strategy_class(
+    ($struct_name:ident, $size_algorithm_type: ty, $struct_name_as_str: expr, $class_name:ident) => {
+        impl NativeClass for $class_name {
+            type Instance = $struct_name;
+
+            const NAME: &'static str = $struct_name_as_str;
+
+            fn constructor(
+                _this: &JsNativeObject<Self::Instance>,
+                args: &[boa_engine::JsValue],
+                context: &mut Context<'_>,
+            ) -> JsResult<Self::Instance> {
+                let init: QueuingStrategyInit = args
+                    .get(0)
+                    .ok_or_else(|| {
+                        JsNativeError::typ()
+                            .with_message(format!("{} constructor: At least 1 argument required, but only 0 passed", $struct_name_as_str))
+                    })?
+                    .try_js_into(context)?;
+                Ok($struct_name::new(init))
+            }
+
+            fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
+                let high_water_mark = Self::high_water_mark(class.context());
+
+                class
+                    .accessor(
+                        js_string!("highWaterMark"),
+                        high_water_mark,
+                        Attribute::READONLY | Attribute::ENUMERABLE | Attribute::CONFIGURABLE,
+                    )
+                    .method(
+                        js_string!("size"),
+                        1,
+                        NativeFunction::from_fn_ptr(Self::size),
+                    );
+                Ok(())
+            }
+        }
+    }
+);
+
+define_builtin_queuing_strategy_class!(
+    CountQueuingStrategy,
+    CountQueuingStrategySizeAlgorithm,
+    "CountQueuingStrategy",
+    CountQueuingStrategyClass
+);
+
+define_builtin_queuing_strategy_class!(
+    ByteLengthQueuingStrategy,
+    ByteLengthQueuingStrategySizeAlgorithm,
+    "ByteLengthQueuingStrategy",
+    ByteLengthQueuingStrategyClass
+);

--- a/crates/jstz_api/src/stream/queuing_strategy/high_water_mark.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/high_water_mark.rs
@@ -1,0 +1,111 @@
+use crate::idl;
+use crate::stream::queuing_strategy::DefaultQueuingStrategy;
+use crate::stream::queuing_strategy::{
+    builtin::{ByteLengthQueuingStrategy, CountQueuingStrategy},
+    QueuingStrategy,
+};
+use boa_engine::{object::NativeObject, JsError, JsNativeError, JsResult};
+use jstz_core::native::JsNativeObject;
+
+/// [Streams Standard - § 7.4.][https://streams.spec.whatwg.org/#validate-and-normalize-high-water-mark]
+/// > `ExtractHighWaterMark(strategy, defaultHWM)`
+pub trait ExtractHighWaterMark {
+    fn extract_high_water_mark(
+        &self,
+        default_hwm: HighWaterMark,
+    ) -> JsResult<HighWaterMark>;
+}
+
+impl ExtractHighWaterMark for DefaultQueuingStrategy {
+    fn extract_high_water_mark(
+        &self,
+        _default_hwm: HighWaterMark,
+    ) -> JsResult<HighWaterMark> {
+        Ok(HighWaterMark::ONE)
+    }
+}
+
+macro_rules! impl_extract_high_water_mark_for_builtin_queuing_strategy {
+    ($T: ty) => {
+        impl ExtractHighWaterMark for $T {
+            fn extract_high_water_mark(
+                &self,
+                _default_hwm: HighWaterMark,
+            ) -> JsResult<HighWaterMark> {
+                HighWaterMark::try_from(self.high_water_mark)
+            }
+        }
+    };
+}
+
+impl_extract_high_water_mark_for_builtin_queuing_strategy!(CountQueuingStrategy);
+impl_extract_high_water_mark_for_builtin_queuing_strategy!(ByteLengthQueuingStrategy);
+
+impl<T: NativeObject + ExtractHighWaterMark> ExtractHighWaterMark for JsNativeObject<T> {
+    fn extract_high_water_mark(
+        &self,
+        default_hwm: HighWaterMark,
+    ) -> JsResult<HighWaterMark> {
+        self.deref().extract_high_water_mark(default_hwm)
+    }
+}
+
+impl ExtractHighWaterMark for QueuingStrategy {
+    fn extract_high_water_mark(
+        &self,
+        default_hwm: HighWaterMark,
+    ) -> JsResult<HighWaterMark> {
+        match self {
+            QueuingStrategy::Default(strategy) => {
+                strategy.extract_high_water_mark(default_hwm)
+            }
+            QueuingStrategy::Count(strategy) => {
+                strategy.extract_high_water_mark(default_hwm)
+            }
+            QueuingStrategy::ByteLength(strategy) => {
+                strategy.extract_high_water_mark(default_hwm)
+            }
+            QueuingStrategy::Custom(_strategy) => {
+                todo!("custom_queuing_strategy.extract_high_water_mark(default_hwm)")
+            }
+        }
+    }
+}
+
+/// A subtype of `idl::UnrestrictedDouble` that only containts values that are neither `NaN` nor negative.
+pub struct HighWaterMark {
+    inner: idl::UnrestrictedDouble,
+}
+
+impl TryFrom<idl::UnrestrictedDouble> for HighWaterMark {
+    type Error = JsError;
+
+    fn try_from(value: idl::UnrestrictedDouble) -> Result<Self, Self::Error> {
+        if value.is_nan() || value < 0.0 {
+            return Err(JsNativeError::range()
+                .with_message("Invalid highWaterMark")
+                .into());
+        }
+        Ok(HighWaterMark { inner: value })
+    }
+}
+
+impl From<HighWaterMark> for idl::UnrestrictedDouble {
+    fn from(value: HighWaterMark) -> idl::UnrestrictedDouble {
+        value.inner
+    }
+}
+
+impl HighWaterMark {
+    pub const ZERO: HighWaterMark = HighWaterMark { inner: 0.0 };
+    pub const ONE: HighWaterMark = HighWaterMark { inner: 1.0 };
+    pub const INFINITY: HighWaterMark = HighWaterMark {
+        inner: idl::UnrestrictedDouble::INFINITY,
+    };
+}
+
+impl Default for HighWaterMark {
+    fn default() -> Self {
+        HighWaterMark::INFINITY
+    }
+}

--- a/crates/jstz_api/src/stream/queuing_strategy/mod.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! A few things to keep in mind:
 //!
-//! - The queuing strategy given to a stream constructor can be either builtin one (i.e. an instance of `CoutQueuingStrategy` or `ByteLengthQueuingStrategy`)
+//! - The queuing strategy given to a stream constructor can be either builtin one (i.e. an instance of `CountQueuingStrategy` or `ByteLengthQueuingStrategy`)
 //!   or a custom one (i.e. anything else).
 //!
 //! - While builtin queuing strategies always have a `highWaterMark` property, custom queuing strategies may not.

--- a/crates/jstz_api/src/stream/queuing_strategy/mod.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/mod.rs
@@ -1,0 +1,67 @@
+//! [Streams Standard - § 7. Queuing strategies][https://streams.spec.whatwg.org/#qs]
+//!
+//! A few things to keep in mind:
+//!
+//! - The queuing strategy given to a stream constructor can be either builtin one (i.e. an instance of `CoutQueuingStrategy` or `ByteLengthQueuingStrategy`)
+//!   or a custom one (i.e. anything else).
+//!
+//! - While builtin queuing strategies always have a `highWaterMark` property, custom queuing strategies may not.
+//!   When the `highWaterMark` property is missing, a default value is used instead. This default value depends on
+//!   the kind of stream being built, as can be seen by looking at the various call to `ExtractHighWaterMark(strategy, defaultHWM)` in the specification.
+//!
+//! - The default queuing strategy is supposed to behave as if it were `new CountQueuingStrategy({highWaterMark: 1.0})`.
+//!
+
+use crate::stream::queuing_strategy::builtin::{
+    ByteLengthQueuingStrategy, ByteLengthQueuingStrategyClass, CountQueuingStrategy,
+    CountQueuingStrategyClass,
+};
+use boa_engine::{value::TryFromJs, Context, JsResult, JsValue};
+use derive_more::*;
+use jstz_core::native::{register_global_class, JsNativeObject};
+
+pub mod builtin;
+pub mod high_water_mark;
+pub mod size;
+
+#[derive(Default)]
+pub struct DefaultQueuingStrategy {}
+
+#[derive(From)]
+pub enum QueuingStrategy {
+    Default(DefaultQueuingStrategy),
+    Count(JsNativeObject<CountQueuingStrategy>),
+    ByteLength(JsNativeObject<ByteLengthQueuingStrategy>),
+    Custom(crate::todo::Todo),
+}
+
+impl Default for QueuingStrategy {
+    fn default() -> Self {
+        (DefaultQueuingStrategy {}).into()
+    }
+}
+
+impl TryFromJs for QueuingStrategy {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        if JsNativeObject::<CountQueuingStrategy>::is(value) {
+            JsNativeObject::<CountQueuingStrategy>::try_from(value.clone())
+                .map(Into::into)
+        } else if JsNativeObject::<ByteLengthQueuingStrategy>::is(value) {
+            JsNativeObject::<ByteLengthQueuingStrategy>::try_from(value.clone())
+                .map(Into::into)
+        } else {
+            todo!("try_from_js(custom_queuing_strategy)")
+        }
+    }
+}
+
+pub struct QueuingStrategyApi;
+
+impl jstz_core::Api for QueuingStrategyApi {
+    fn init(self, context: &mut Context<'_>) {
+        register_global_class::<CountQueuingStrategyClass>(context)
+            .expect("The `CountQueuingStrategy` class shouldn't exist yet");
+        register_global_class::<ByteLengthQueuingStrategyClass>(context)
+            .expect("The `ByteLengthQueuingStrategy` class shouldn't exist yet");
+    }
+}

--- a/crates/jstz_api/src/stream/queuing_strategy/size.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/size.rs
@@ -1,0 +1,156 @@
+use crate::{idl, stream::queuing_strategy::*, stream::Chunk};
+use boa_engine::{object::NativeObject, Context, JsResult};
+use boa_gc::{Finalize, Trace};
+use jstz_core::{js_fn::JsCallableWithoutThis, native::JsNativeObject};
+
+pub trait ExtractSizeAlgorithm {
+    // The type of the extracted size algorithm. It could just be `QueuingStrategySizeAlgorithm`.
+    // We allow it to vary to avoid wrapping in a constructor of the enum `QueuingStrategySizeAlgorithm` and immediately unwrapping when immediately calling the size algorithm.
+    type ESA: Into<QueuingStrategySizeAlgorithm>
+        + JsCallableWithoutThis<(Chunk,), idl::UnrestrictedDouble>;
+    fn extract_size_algorithm(&self) -> Self::ESA;
+}
+
+impl ExtractSizeAlgorithm for DefaultQueuingStrategy {
+    type ESA = CountQueuingStrategySizeAlgorithm;
+
+    fn extract_size_algorithm(&self) -> Self::ESA {
+        CountQueuingStrategySizeAlgorithm::ReturnOne
+    }
+}
+
+#[derive(Default, Finalize, Trace)]
+pub enum CountQueuingStrategySizeAlgorithm {
+    #[default]
+    ReturnOne,
+}
+
+impl CountQueuingStrategySizeAlgorithm {
+    pub const RETURN_VALUE: idl::UnrestrictedDouble = 1.0;
+}
+
+impl JsCallableWithoutThis<(Chunk,), idl::UnrestrictedDouble>
+    for CountQueuingStrategySizeAlgorithm
+{
+    fn call_without_this(
+        &self,
+        _inputs: (Chunk,),
+        _context: &mut Context<'_>,
+    ) -> JsResult<idl::UnrestrictedDouble> {
+        match self {
+            CountQueuingStrategySizeAlgorithm::ReturnOne => {
+                Ok(CountQueuingStrategySizeAlgorithm::RETURN_VALUE)
+            }
+        }
+    }
+}
+
+impl ExtractSizeAlgorithm for CountQueuingStrategy {
+    type ESA = CountQueuingStrategySizeAlgorithm;
+
+    fn extract_size_algorithm(&self) -> Self::ESA {
+        CountQueuingStrategySizeAlgorithm::ReturnOne
+    }
+}
+
+#[derive(Default, Finalize, Trace)]
+pub enum ByteLengthQueuingStrategySizeAlgorithm {
+    #[default]
+    ReturnByteLengthOfChunk,
+}
+
+impl JsCallableWithoutThis<(Chunk,), idl::UnrestrictedDouble>
+    for ByteLengthQueuingStrategySizeAlgorithm
+{
+    fn call_without_this(
+        &self,
+        _inputs: (Chunk,),
+        _context: &mut Context<'_>,
+    ) -> JsResult<idl::UnrestrictedDouble> {
+        match self {
+            ByteLengthQueuingStrategySizeAlgorithm::ReturnByteLengthOfChunk => {
+                todo!("ReturnByteLengthOfChunk.call_without_this()")
+            }
+        }
+    }
+}
+
+impl ExtractSizeAlgorithm for ByteLengthQueuingStrategy {
+    type ESA = ByteLengthQueuingStrategySizeAlgorithm;
+
+    fn extract_size_algorithm(&self) -> Self::ESA {
+        ByteLengthQueuingStrategySizeAlgorithm::ReturnByteLengthOfChunk
+    }
+}
+
+impl<T: NativeObject + ExtractSizeAlgorithm> ExtractSizeAlgorithm for JsNativeObject<T> {
+    type ESA = T::ESA;
+
+    fn extract_size_algorithm(&self) -> Self::ESA {
+        self.deref().extract_size_algorithm()
+    }
+}
+
+#[derive(From)]
+pub enum QueuingStrategySizeAlgorithm {
+    Count(CountQueuingStrategySizeAlgorithm),
+    ByteLength(ByteLengthQueuingStrategySizeAlgorithm),
+    Custom(crate::todo::Todo),
+}
+
+impl JsCallableWithoutThis<(Chunk,), idl::UnrestrictedDouble>
+    for QueuingStrategySizeAlgorithm
+{
+    fn call_without_this(
+        &self,
+        inputs: (Chunk,),
+        context: &mut Context<'_>,
+    ) -> JsResult<idl::UnrestrictedDouble> {
+        match self {
+            QueuingStrategySizeAlgorithm::Count(size_algorithm) => {
+                size_algorithm.call_without_this(inputs, context)
+            }
+            QueuingStrategySizeAlgorithm::ByteLength(size_algorithm) => {
+                size_algorithm.call_without_this(inputs, context)
+            }
+            QueuingStrategySizeAlgorithm::Custom(_size_algorithm) => {
+                todo!("custom_size_algorithm.call_without_this(inputs, context)")
+            }
+        }
+    }
+}
+
+impl ExtractSizeAlgorithm for QueuingStrategy {
+    type ESA = QueuingStrategySizeAlgorithm;
+
+    fn extract_size_algorithm(&self) -> Self::ESA {
+        match self {
+            QueuingStrategy::Default(strategy) => {
+                strategy.extract_size_algorithm().into()
+            }
+            QueuingStrategy::Count(strategy) => strategy.extract_size_algorithm().into(),
+            QueuingStrategy::ByteLength(strategy) => {
+                strategy.extract_size_algorithm().into()
+            }
+            QueuingStrategy::Custom(_strategy) => {
+                todo!("custom_queuing_strategy.extract_size_algorithm()")
+            }
+        }
+    }
+}
+
+impl Default for QueuingStrategySizeAlgorithm {
+    fn default() -> Self {
+        CountQueuingStrategySizeAlgorithm::ReturnOne.into()
+    }
+}
+
+impl ExtractSizeAlgorithm for Option<QueuingStrategy> {
+    type ESA = QueuingStrategySizeAlgorithm;
+
+    fn extract_size_algorithm(&self) -> Self::ESA {
+        self.as_ref()
+            .map(|v| v.extract_size_algorithm())
+            .unwrap_or_default()
+    }
+}

--- a/crates/jstz_api/src/stream/readable/underlying_source.rs
+++ b/crates/jstz_api/src/stream/readable/underlying_source.rs
@@ -6,7 +6,10 @@ use boa_engine::{
 };
 use boa_gc::{custom_trace, Finalize, Trace};
 use jstz_core::{
-    impl_into_js_from_into, js_fn::JsFn, native::JsNativeObject, value::IntoJs,
+    impl_into_js_from_into,
+    js_fn::{JsCallable, JsFn},
+    native::JsNativeObject,
+    value::IntoJs,
 };
 use std::str::FromStr;
 

--- a/crates/jstz_core/src/js_fn.rs
+++ b/crates/jstz_core/src/js_fn.rs
@@ -46,7 +46,6 @@ impl<T0: IntoJs, T1: IntoJs, T2: IntoJs> IntoJsArgs for (T0, T1, T2) {
 
 /// A `JsFn<T, I, O>` is a `JsFunction` tagged with some Rust types used to handle the `TryFromJs` and `IntoJs` conversions automatically:
 /// - `T` is the type of the `this` parameter;
-/// - `N` is the arity;
 /// - `I` is a tuple `(I1, ..., IN)` that contains the types of the parameters;
 /// - `O` is the type of the output.
 #[derive(Debug)]
@@ -112,8 +111,12 @@ impl<T: IntoJs, I: IntoJsArgs, O: TryFromJs> TryFromJs for JsFn<T, I, O> {
     }
 }
 
-impl<T: IntoJs, I: IntoJsArgs, O: TryFromJs> JsFn<T, I, O> {
-    pub fn call(&self, this: T, inputs: I, context: &mut Context<'_>) -> JsResult<O> {
+pub trait JsCallable<T, I, O> {
+    fn call(&self, this: T, inputs: I, context: &mut Context<'_>) -> JsResult<O>;
+}
+
+impl<T: IntoJs, I: IntoJsArgs, O: TryFromJs> JsCallable<T, I, O> for JsFn<T, I, O> {
+    fn call(&self, this: T, inputs: I, context: &mut Context<'_>) -> JsResult<O> {
         let js_this = this.into_js(context);
         let js_args = inputs.into_js_args(context);
         self.deref()

--- a/crates/jstz_core/src/value.rs
+++ b/crates/jstz_core/src/value.rs
@@ -5,7 +5,7 @@ use boa_engine::{
         JsMapIterator, JsPromise, JsProxy, JsRegExp, JsSet, JsSetIterator, JsTypedArray,
         JsUint16Array, JsUint32Array, JsUint8Array,
     },
-    Context, JsBigInt, JsObject, JsString, JsSymbol,
+    Context, JsBigInt, JsNativeError, JsObject, JsString, JsSymbol,
 };
 
 pub use boa_engine::value::*;
@@ -104,3 +104,33 @@ where
         JsArray::from_iter(values, context).into()
     }
 }
+
+/// A unit type that corresponds to an undefined JS value
+#[derive(Default)]
+pub enum JsUndefined {
+    #[default]
+    Undefined,
+}
+
+impl TryFromJs for JsUndefined {
+    fn try_from_js(
+        value: &JsValue,
+        _context: &mut Context<'_>,
+    ) -> boa_engine::prelude::JsResult<Self> {
+        if value.is_undefined() {
+            Ok(JsUndefined::Undefined)
+        } else {
+            Err(JsNativeError::typ()
+                .with_message(format!("Expected undefined but found {:?}", value))
+                .into())
+        }
+    }
+}
+
+impl From<JsUndefined> for JsValue {
+    fn from(_: JsUndefined) -> Self {
+        JsValue::undefined()
+    }
+}
+
+impl_into_js_from_into!(JsUndefined);


### PR DESCRIPTION
# Description

This implements part of the [queuing strategy](https://streams.spec.whatwg.org/#qs-api) section of the Stream WebAPI. The main goal was to implement `CountQueuingStrategy`, but since most of the code could be shared through simple macros, most of `ByteLengthQueuingStrategy` is also implemented (with the only remaining being finishing the implementation of its size algorithm).

# Manual testing


```sh
nix develop
cargo run --bin jstz -- repl

>> new CountQueuingStrategy()
✕  ERROR  Uncaught TypeError: CountQueuingStrategy constructor: At least 1 argument required, but only 0 passed
>> new CountQueuingStrategy(1)
✕  ERROR  Uncaught TypeError: Missing required highWaterMark property
>> new CountQueuingStrategy({})
✕  ERROR  Uncaught TypeError: Missing required highWaterMark property

>> strat = new CountQueuingStrategy({highWaterMark: 1})

>> strat.highWaterMark
1
>> strat.highWaterMark = 2 // Does nothing because highWaterMark is readonly
2
>> strat.highWaterMark
1

>> strat.size()
1
>> strat.size(3)
1
>> strat.size({})
1

>> bad_strat = new CountQueuingStrategy({highWaterMark: -1}) // Creating this object is fine
>> bad_strat.highWaterMark
-1
>> new ReadableStream({}, bad_strat) // But using it in ReadableStream's constructor causes an error
✕  ERROR  Uncaught RangeError: Invalid highWaterMark

>> new ReadableStream({}, strat)
thread 'main' panicked at crates/jstz_api/src/stream/readable/mod.rs:67:13:
not yet implemented: SetUpReadableStreamDefaultControllerFromUnderlyingSource
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
# Checklist

- [x] Changes follow the existing code style (use `make fmt-check` to check)
- [ ] Tests for changes have been added
- [ ] Internal documentation has been added (if appropriate)
- [x] Testing instructions have been added to PR
