### PR TITLE
Cli: enable run --trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,6 +2183,7 @@ dependencies = [
  "tezos_crypto_rs",
  "tiny-bip39",
  "tokio",
+ "tokio-util",
  "url",
 ]
 

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -61,6 +61,7 @@ spinners = "4.1.1"
 regex = "1"
 indicatif = "0.17.0"
 simplelog = "0.11"
+tokio-util = "0.7.10"
 
 [[bin]]
 name = "jstz"

--- a/crates/jstz_cli/src/logs/mod.rs
+++ b/crates/jstz_cli/src/logs/mod.rs
@@ -5,7 +5,8 @@ use crate::{config::NetworkName, utils::AddressOrAlias, Result};
 
 mod trace;
 
-use trace::DEFAULT_LOG_LEVEL;
+pub use trace::exec_trace;
+pub use trace::DEFAULT_LOG_LEVEL;
 
 #[derive(Debug, Subcommand)]
 pub enum Command {

--- a/crates/jstz_cli/src/logs/trace.rs
+++ b/crates/jstz_cli/src/logs/trace.rs
@@ -1,8 +1,8 @@
-use futures_util::stream::StreamExt;
+use futures_util::{stream::StreamExt, Future};
 use jstz_api::js_log::LogLevel;
 use jstz_proto::js_logger::LogRecord;
 use log::{debug, error, info};
-use reqwest_eventsource::Event;
+use reqwest_eventsource::{Event, EventSource};
 
 use crate::{config::NetworkName, error::Result, utils::AddressOrAlias, Config};
 
@@ -18,11 +18,30 @@ pub async fn exec(
     let address = address_or_alias.resolve(&cfg)?;
     debug!("resolved `address_or_alias` -> {:?}", address);
 
-    let mut event_source = cfg.jstz_client(network)?.logs_stream(&address);
+    let event_source = cfg.jstz_client(network)?.logs_stream(&address);
 
+    exec_trace(event_source, log_level, || async {
+        info!("Connected to smart function '{}'.", address);
+    })
+    .await?;
+
+    Ok(())
+}
+
+pub async fn exec_trace<F, Fut>(
+    mut event_source: EventSource,
+    log_level: LogLevel,
+    on_connect: F,
+) -> Result<()>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = ()>,
+{
     while let Some(event) = event_source.next().await {
         match event {
-            Ok(Event::Open) => info!("Event source opened."),
+            Ok(Event::Open) => {
+                on_connect().await;
+            }
             Ok(Event::Message(message)) => {
                 if let Ok(log_record) = serde_json::from_str::<LogRecord>(&message.data) {
                     let LogRecord { level, text, .. } = log_record;

--- a/crates/jstz_cli/src/main.rs
+++ b/crates/jstz_cli/src/main.rs
@@ -80,6 +80,9 @@ enum Command {
         ///  Use `dev` for the local sandbox.
         #[arg(short, long, default_value = None)]
         network: Option<NetworkName>,
+        /// Flag for logging.
+        #[arg(short, long)]
+        trace: bool,
     },
     /// ⚡️ Start a REPL session with jstz's JavaScript runtime.
     Repl {
@@ -122,7 +125,8 @@ async fn exec(command: Command) -> Result<()> {
             gas_limit,
             json_data,
             network,
-        } => run::exec(url, http_method, gas_limit, json_data, network).await,
+            trace,
+        } => run::exec(url, http_method, gas_limit, json_data, network, trace).await,
         Command::Repl { account } => repl::exec(account),
         Command::Logs(logs) => logs::exec(logs).await,
         Command::Login { alias } => account::login(alias),

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -114,10 +114,13 @@ pub async fn exec(
         styles::url(&url_object.to_string())
     );
 
-    let mut spinner = Spinner::new(Spinners::BoxBounce2, "".into());
+    let mut spinner = if trace {
+        None
+    } else {
+        Some(Spinner::new(Spinners::BoxBounce2, "".into()))
+    };
+
     if trace {
-        spinner.stop();
-        println!();
         let address = address_or_alias.resolve(&cfg)?;
         spawn_trace(&address, &jstz_client).await?;
     }
@@ -137,10 +140,12 @@ pub async fn exec(
         Err(err) => bail_user_error!("{err}"),
     };
 
-    spinner.stop();
-    println!();
+    if let Some(spinner) = spinner.as_mut() {
+        spinner.stop_with_symbol(&format!("Status code: {}", status_code));
+    } else {
+        info!("Status code: {}", status_code);
+    }
 
-    info!("Status code: {}", status_code);
     info!("Headers: {:?}", headers);
     if let Some(body) = body {
         info!("Body: {}", String::from_utf8_lossy(&body));


### PR DESCRIPTION
# Context


[run --trace](https://app.asana.com/0/1205770721173531/1206394772057371/f)

# Description

Show the log trace when running the contract.
I also turned off the spinner immediately in case the trace is enabled as it clash with other texts

# Manually testing the PR

jstz run <url> --trace 



https://github.com/trilitech/jstz/assets/128799322/baca0c4f-ca9f-422b-8b6e-3151ae0a0e8b

