### PR TITLE
fix: check smart function code parses before continuing

### DIFF
--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -1,4 +1,6 @@
+use boa_engine::JsError;
 use jstz_proto::{
+    context::account::ParsedCode,
     operation::{Content, DeployFunction, Operation, SignedOperation},
     receipt::Content as ReceiptContent,
 };
@@ -44,6 +46,9 @@ pub async fn exec(
 
     debug!("Code: {}", code);
 
+    let code: ParsedCode = code
+        .try_into()
+        .map_err(|err: JsError| user_error!("{err}"))?;
     let op = Operation {
         source: user.address.clone(),
         nonce,

--- a/crates/jstz_proto/src/api/smart_function.rs
+++ b/crates/jstz_proto/src/api/smart_function.rs
@@ -13,7 +13,7 @@ use jstz_core::{
 };
 
 use crate::{
-    context::account::{Account, Address, Amount},
+    context::account::{Account, Address, Amount, ParsedCode},
     executor::smart_function::{headers, Script},
     operation::OperationHash,
     Error, Result,
@@ -59,7 +59,7 @@ impl SmartFunction {
         &self,
         hrt: &impl HostRuntime,
         tx: &mut Transaction,
-        function_code: String,
+        function_code: ParsedCode,
         initial_balance: Amount,
     ) -> Result<String> {
         // 1. Check if the associated account has sufficient balance
@@ -162,6 +162,7 @@ impl SmartFunctionApi {
                     .with_message("Expected at least 1 argument but 0 provided")
             })?
             .try_js_into(context)?;
+        let parsed_code: ParsedCode = function_code.try_into()?;
 
         let initial_balance = match args.get(1) {
             None => 0,
@@ -178,7 +179,7 @@ impl SmartFunctionApi {
                     smart_function.create(
                         hrt.deref(),
                         tx,
-                        function_code,
+                        parsed_code,
                         initial_balance as Amount,
                     )
                 })?;

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -23,7 +23,7 @@ use tezos_smart_rollup::prelude::debug_msg;
 
 use crate::{
     api::{self, TraceData},
-    context::account::{Account, Address, Amount},
+    context::account::{Account, Address, Amount, ParsedCode},
     operation::OperationHash,
     request_logger::{log_request_end, log_request_start},
     Error, Result,
@@ -205,7 +205,7 @@ impl Script {
         hrt: &impl HostRuntime,
         tx: &mut Transaction,
         source: &Address,
-        code: String,
+        code: ParsedCode,
         balance: Amount,
     ) -> Result<Address> {
         let nonce = Account::nonce(hrt, tx, source)?;

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -5,7 +5,7 @@ use jstz_crypto::{hash::Blake2b, public_key::PublicKey, signature::Signature};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    context::account::{Account, Address, Amount, Nonce},
+    context::account::{Account, Address, Amount, Nonce, ParsedCode},
     Error, Result,
 };
 
@@ -92,7 +92,7 @@ impl Operation {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct DeployFunction {
-    pub function_code: String,
+    pub function_code: ParsedCode,
     pub account_credit: Amount,
 }
 

--- a/examples/deploy.js
+++ b/examples/deploy.js
@@ -1,3 +1,10 @@
+async function deploySmartFunction(code) {
+  console.log(code);
+  const smartFunctionAddress = await SmartFunction.create(code);
+  console.log("created", smartFunctionAddress);
+  return smartFunctionAddress;
+}
+async function deployTwice() {}
 async function handler() {
   const code = `
 export default (request) => {
@@ -7,10 +14,24 @@ export default (request) => {
   return new Response();
 }
   `;
+  const rustCode = `
+pub fn default (request: Request) -> Response {
+  console.log("Hello World");
+  let arg = request.text();
+  console.log(arg);
+  Response::new();
+}
+  `;
 
-  console.log(code);
-  const smartFunctionAddress = await SmartFunction.create(code);
-  console.log("created", smartFunctionAddress);
+  let smartFunctionAddress;
+  try {
+    console.log("Trying to deploy smart contract in rust.");
+    smartFunctionAddress = await deploySmartFunction(rustCode);
+  } catch (err) {
+    console.error(err);
+    console.log("Trying again with javascript.");
+    smartFunctionAddress = await deploySmartFunction(code);
+  }
 
   await fetch(
     new Request(`tezos://${smartFunctionAddress}/`, {
@@ -18,14 +39,6 @@ export default (request) => {
       body: "Hello World",
     }),
   );
-
-  await fetch(
-    new Request(`tezos://${smartFunctionAddress}/`, {
-      method: "POST",
-      body: "Hello World",
-    }),
-  );
-
   return new Response();
 }
 


### PR DESCRIPTION
# Context
Currently if we deploy a contract it is not checked whether it parses or not. This means the kernel panics when the contract is called.  This PR fixes that by raising an error when the contract is deployed. 

**Related Tasks**: [Add check to see if JS parses when deploying contract](https://app.asana.com/0/1205770721173531/1205770721309638/f)

# Description
* Introduces a new type `ParsedCode` as a witness that the code has been parsed.
* Changes the deployment logic to uses ParsedCode and not String.
* Updates the CLI to pass ParsedCode not strings so that we can perform the checks before deploying.

# Manually testing the PR

```bash
# for the cli
echo "fn default(request: Request) -> Response { response::new() }" | jstz deploy # parse error

# for the rollup
jstz deploy --name test_deploy examples/deploy.js
jstz run tezos://test_deploy
```
