### PR TITLE
fix(cli): fixup new keys

### DIFF
--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -141,9 +141,6 @@ impl AccountConfig {
             inner: self.accounts.iter(),
         }
     }
-    pub fn is_empty(&self) -> bool {
-        self.accounts.is_empty() && self.current_alias.is_none()
-    }
 }
 
 impl AddressOrAlias {
@@ -199,12 +196,13 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<SandboxConfig>,
     /// List of accounts
-    #[serde(default, flatten, skip_serializing_if = "AccountConfig::is_empty")]
+    #[serde(flatten)]
     pub accounts: AccountConfig,
     /// Available networks
-    #[serde(default, flatten, skip_serializing_if = "NetworkConfig::is_empty")]
+    #[serde(flatten)]
     pub networks: NetworkConfig,
     /// Sandbox logs dir
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox_logs_dir: Option<PathBuf>,
 }
 
@@ -256,14 +254,12 @@ struct Network {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct NetworkConfig {
     // if None, the users have to specify the network in the command
+    #[serde(skip_serializing_if = "Option::is_none")]
     default_network: Option<NetworkName>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     networks: HashMap<String, Network>,
 }
-impl NetworkConfig {
-    pub fn is_empty(&self) -> bool {
-        self.default_network.is_none() && self.networks.is_empty()
-    }
-}
+
 impl Config {
     /// Path to the configuration file
     pub fn path() -> PathBuf {


### PR DESCRIPTION
# Context

Patch for (#422)[https://github.com/trilitech/jstz/pull/422]  to handle upstream config changes.

# Description

This PR assigns default values if the `networks` or `sandbox_logs_dir` fields are missing. These were omitted from the previous PR when merging with `main`

# Manually testing this pr
### Backup your config file first!
```bash
# clear all fields from the config
echo "{}" > ~/.jstz/config.json

# anything that accesses or changes the config
jstz login sam
cat ~/.config.json
```
