### PR TITLE
fix(cli): remove double emojis in account code 🧑‍💻=🧑‍ 💻 -> 💻

### DIFF
--- a/crates/jstz_cli/src/account.rs
+++ b/crates/jstz_cli/src/account.rs
@@ -292,7 +292,7 @@ pub enum Command {
         #[arg(short, long)]
         long: bool,
     },
-    /// 🧑‍💻 Outputs the deployed code for an account.
+    /// 💻 Outputs the deployed code for an account.
     Code {
         /// Smart function address or alias.
         #[arg(short, long, value_name = "ALIAS|ADDRESS")]


### PR DESCRIPTION
# Context
In help for account code there is this emoji - 🧑‍💻 which however gets diplayed as two emojis 🧑‍ 💻 which breaks the text alignment in help.
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
This PR changes 🧑‍💻 to 💻.

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
jstz account help
<!-- Describe how reviewers and approvers can test this PR. -->
