### PR TITLE
fix(cli): add `tx.begin()` in the REPL

### DIFF
--- a/crates/jstz_cli/src/repl/mod.rs
+++ b/crates/jstz_cli/src/repl/mod.rs
@@ -121,6 +121,7 @@ pub fn exec(account: Option<AddressOrAlias>) -> Result<()> {
     let mut rt = Runtime::new(DEFAULT_GAS_LIMIT)
         .map_err(|_| anyhow!("Failed to initialize jstz's JavaScript runtime."))?;
     let mut tx = Transaction::default();
+    tx.begin();
 
     set_js_logger(&PrettyLogger);
 


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [`SmartFunction.create()` does not work in REPL](https://app.asana.com/0/1205770721173531/1206695470748493/f)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR fixes the `TransactionStackEmpty` error when interacting with `Kv`, `Ledger` or `SmartFunction` in the REPL

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
jstz repl
>> Kv.get("foobar")
```