### PR TITLE
fix(core): fix native class constructor method

### DIFF
--- a/crates/jstz_api/src/encoding/text_decoder.rs
+++ b/crates/jstz_api/src/encoding/text_decoder.rs
@@ -8,9 +8,7 @@ use boa_gc::{Finalize, GcRefMut, Trace};
 use encoding_rs::{Decoder, DecoderResult, Encoding};
 use jstz_core::{
     accessor,
-    native::{
-        register_global_class, Accessor, ClassBuilder, JsNativeObject, NativeClass,
-    },
+    native::{register_global_class, Accessor, ClassBuilder, NativeClass},
     value::{IntoJs, TryFromJs},
 };
 
@@ -329,8 +327,8 @@ impl NativeClass for TextDecoderClass {
 
     const NAME: &'static str = "TextDecoder";
 
-    fn constructor(
-        _this: &JsNativeObject<TextDecoder>,
+    fn data_constructor(
+        _target: &JsValue,
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<TextDecoder> {

--- a/crates/jstz_api/src/encoding/text_encoder.rs
+++ b/crates/jstz_api/src/encoding/text_encoder.rs
@@ -85,8 +85,8 @@ impl NativeClass for TextEncoderEncodeIntoResult {
 
     const NAME: &'static str = "TextEncoderEncodeIntoResult";
 
-    fn constructor(
-        _this: &JsNativeObject<TextEncoderEncodeIntoResult>,
+    fn data_constructor(
+        _target: &JsValue,
         _args: &[JsValue],
         _: &mut Context<'_>,
     ) -> JsResult<TextEncoderEncodeIntoResult> {
@@ -255,8 +255,8 @@ impl NativeClass for TextEncoderClass {
 
     const NAME: &'static str = "TextEncoder";
 
-    fn constructor(
-        _this: &JsNativeObject<TextEncoder>,
+    fn data_constructor(
+        _target: &JsValue,
         _args: &[JsValue],
         _: &mut Context<'_>,
     ) -> JsResult<TextEncoder> {

--- a/crates/jstz_api/src/file/blob.rs
+++ b/crates/jstz_api/src/file/blob.rs
@@ -23,7 +23,9 @@ use boa_engine::{
 use boa_gc::{Finalize, GcRefMut, Trace};
 use jstz_core::{
     accessor,
-    native::{register_global_class, Accessor, JsNativeObject, NativeClass},
+    native::{
+        register_global_class, Accessor, ClassBuilder, JsNativeObject, NativeClass,
+    },
     value::IntoJs,
 };
 use std::cmp::{max, min};
@@ -472,11 +474,11 @@ impl NativeClass for BlobClass {
 
     const NAME: &'static str = "Blob";
 
-    fn constructor(
-        _this: &jstz_core::native::JsNativeObject<Self::Instance>,
-        args: &[boa_engine::prelude::JsValue],
-        context: &mut boa_engine::prelude::Context<'_>,
-    ) -> boa_engine::prelude::JsResult<Self::Instance> {
+    fn data_constructor(
+        _target: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<Self::Instance> {
         let blob_parts: Option<BlobParts> =
             args.get_or_undefined(0).try_js_into(context)?;
         let options: Option<BlobPropertyBag> =
@@ -485,9 +487,7 @@ impl NativeClass for BlobClass {
         Blob::new(blob_parts, options, context)
     }
 
-    fn init(
-        class: &mut jstz_core::native::ClassBuilder<'_, '_>,
-    ) -> boa_engine::prelude::JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
         let size = Self::size(class.context());
         let type_ = Self::type_(class.context());
 

--- a/crates/jstz_api/src/file/file.rs
+++ b/crates/jstz_api/src/file/file.rs
@@ -22,7 +22,9 @@ use boa_engine::{
 use boa_gc::{Finalize, GcRefMut, Trace};
 use jstz_core::{
     accessor,
-    native::{register_global_class, Accessor, JsNativeObject, NativeClass},
+    native::{
+        register_global_class, Accessor, ClassBuilder, JsNativeObject, NativeClass,
+    },
     value::IntoJs,
 };
 
@@ -237,11 +239,11 @@ impl NativeClass for FileClass {
 
     const NAME: &'static str = "File";
 
-    fn constructor(
-        _this: &jstz_core::native::JsNativeObject<Self::Instance>,
-        args: &[boa_engine::prelude::JsValue],
-        context: &mut boa_engine::prelude::Context<'_>,
-    ) -> boa_engine::prelude::JsResult<Self::Instance> {
+    fn data_constructor(
+        _target: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<Self::Instance> {
         let blob_parts: BlobParts = args.get_or_undefined(0).try_js_into(context)?;
         let file_name: String = args.get_or_undefined(1).try_js_into(context)?;
         let options: Option<FilePropertyBag> =
@@ -250,9 +252,7 @@ impl NativeClass for FileClass {
         File::new(blob_parts, file_name, &options, context)
     }
 
-    fn init(
-        class: &mut jstz_core::native::ClassBuilder<'_, '_>,
-    ) -> boa_engine::prelude::JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
         let name = Self::name(class.context());
         let last_modified = Self::last_modified(class.context());
         let size = Self::size(class.context());

--- a/crates/jstz_api/src/http/header.rs
+++ b/crates/jstz_api/src/http/header.rs
@@ -26,7 +26,7 @@ use derive_more::Deref;
 use http::{header::Entry, HeaderMap, HeaderName, HeaderValue};
 use jstz_core::{
     iterators::{PairIterable, PairIterableMethods, PairIteratorClass, PairValue},
-    native::{register_global_class, ClassBuilder, JsNativeObject, NativeClass},
+    native::{register_global_class, ClassBuilder, NativeClass},
     value::IntoJs,
 };
 #[derive(Default, Clone, Deref)]
@@ -558,8 +558,8 @@ impl NativeClass for HeadersClass {
 
     const NAME: &'static str = "Headers";
 
-    fn constructor(
-        _this: &JsNativeObject<Headers>,
+    fn data_constructor(
+        _target: &JsValue,
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<Headers> {

--- a/crates/jstz_api/src/http/request.rs
+++ b/crates/jstz_api/src/http/request.rs
@@ -449,8 +449,8 @@ impl NativeClass for RequestClass {
 
     const NAME: &'static str = "Request";
 
-    fn constructor(
-        _this: &JsNativeObject<Self::Instance>,
+    fn data_constructor(
+        _target: &JsValue,
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<Self::Instance> {

--- a/crates/jstz_api/src/http/response.rs
+++ b/crates/jstz_api/src/http/response.rs
@@ -529,9 +529,9 @@ impl NativeClass for ResponseClass {
 
     const NAME: &'static str = "Response";
 
-    fn constructor(
-        _this: &JsNativeObject<Self::Instance>,
-        args: &[boa_engine::JsValue],
+    fn data_constructor(
+        _target: &JsValue,
+        args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<Self::Instance> {
         let body: BodyWithType = match args.get(0) {

--- a/crates/jstz_api/src/stream/queuing_strategy/builtin.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/builtin.rs
@@ -15,7 +15,7 @@ use boa_gc::{Finalize, GcRefMut, Trace};
 use jstz_core::{
     accessor,
     js_fn::JsCallableWithoutThis,
-    native::{Accessor, ClassBuilder, JsNativeObject, NativeClass},
+    native::{Accessor, ClassBuilder, NativeClass},
 };
 
 /// [Streams Standard - § 7.1.][https://streams.spec.whatwg.org/#qs-api]
@@ -166,9 +166,9 @@ macro_rules! define_builtin_queuing_strategy_class(
 
             const NAME: &'static str = $struct_name_as_str;
 
-            fn constructor(
-                _this: &JsNativeObject<Self::Instance>,
-                args: &[boa_engine::JsValue],
+            fn data_constructor(
+                _target: &JsValue,
+                args: &[JsValue],
                 context: &mut Context<'_>,
             ) -> JsResult<Self::Instance> {
                 let init: QueuingStrategyInit = args

--- a/crates/jstz_api/src/stream/readable/mod.rs
+++ b/crates/jstz_api/src/stream/readable/mod.rs
@@ -6,11 +6,9 @@ use crate::stream::{
     },
     readable::underlying_source::{ReadableStreamType, UnderlyingSource},
 };
-use boa_engine::{value::TryFromJs, Context, JsArgs, JsResult};
+use boa_engine::{value::TryFromJs, Context, JsArgs, JsResult, JsValue};
 use boa_gc::{custom_trace, Finalize, Trace};
-use jstz_core::native::{
-    register_global_class, ClassBuilder, JsNativeObject, NativeClass,
-};
+use jstz_core::native::{register_global_class, ClassBuilder, NativeClass};
 
 pub mod underlying_source;
 
@@ -38,9 +36,9 @@ impl NativeClass for ReadableStreamClass {
 
     const NAME: &'static str = "ReadableStream";
 
-    fn constructor(
-        _this: &JsNativeObject<Self::Instance>,
-        args: &[boa_engine::JsValue],
+    fn data_constructor(
+        _target: &JsValue,
+        args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<Self::Instance> {
         let underlying_source =

--- a/crates/jstz_api/src/url/mod.rs
+++ b/crates/jstz_api/src/url/mod.rs
@@ -71,7 +71,6 @@ impl Url {
     ///
     /// [spec] https://url.spec.whatwg.org/#dom-url-url
     pub fn new(
-        this: &JsNativeObject<Self>,
         url: String,
         base: Option<String>,
         context: &mut Context<'_>,
@@ -95,9 +94,6 @@ impl Url {
                 context,
             )?,
         };
-
-        // 7. Set `url`’s query object’s URL object to `url`.
-        url.search_params.deref_mut().set_url(this);
 
         Ok(url)
     }
@@ -448,15 +444,26 @@ impl NativeClass for UrlClass {
 
     const NAME: &'static str = "URL";
 
-    fn constructor(
-        this: &JsNativeObject<Url>,
+    fn data_constructor(
+        _target: &JsValue,
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<Url> {
         let url: String = args.get_or_undefined(0).try_js_into(context)?;
         let base: Option<String> = args.get_or_undefined(1).try_js_into(context)?;
 
-        Url::new(this, url, base, context)
+        Url::new(url, base, context)
+    }
+
+    fn object_constructor(
+        this: &JsNativeObject<Self::Instance>,
+        _args: &[JsValue],
+        _context: &mut Context<'_>,
+    ) -> JsResult<()> {
+        // 7. Set `this`’s query object’s URL object to `this`.
+        this.deref_mut().search_params.deref_mut().set_url(this);
+
+        Ok(())
     }
 
     fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {

--- a/crates/jstz_api/src/url/search_params.rs
+++ b/crates/jstz_api/src/url/search_params.rs
@@ -460,8 +460,8 @@ impl NativeClass for UrlSearchParamsClass {
 
     const NAME: &'static str = "URLSearchParams";
 
-    fn constructor(
-        _this: &JsNativeObject<UrlSearchParams>,
+    fn data_constructor(
+        _target: &JsValue,
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<UrlSearchParams> {

--- a/crates/jstz_api/src/urlpattern.rs
+++ b/crates/jstz_api/src/urlpattern.rs
@@ -92,7 +92,6 @@ impl UrlPattern {
     // nor in `urlpattern` crate. There is an open PR for supporting it in
     // `urlpattern`: https://github.com/denoland/rust-urlpattern/pull/34
     pub fn new(
-        _this: &JsNativeObject<Self>,
         input: UrlPatternInput,
         base_url: Option<String>,
         _context: &mut Context<'_>,
@@ -483,8 +482,8 @@ impl NativeClass for UrlPatternClass {
 
     const NAME: &'static str = "URLPattern";
 
-    fn constructor(
-        this: &JsNativeObject<UrlPattern>,
+    fn data_constructor(
+        _target: &JsValue,
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<UrlPattern> {
@@ -494,7 +493,7 @@ impl NativeClass for UrlPatternClass {
         };
         let base_url: Option<String> = args.get_or_undefined(1).try_js_into(context)?;
 
-        UrlPattern::new(this, input, base_url, context)
+        UrlPattern::new(input, base_url, context)
     }
 
     fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {

--- a/crates/jstz_core/src/iterators.rs
+++ b/crates/jstz_core/src/iterators.rs
@@ -424,8 +424,8 @@ impl<T: PairIteratorClass> NativeClass for T {
     // instantiated by jstz
     const LENGTH: usize = 2;
 
-    fn constructor(
-        _this: &JsNativeObject<Self::Instance>,
+    fn data_constructor(
+        _target: &JsValue,
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<Self::Instance> {


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Panics in URL / URLSearchParams](https://app.asana.com/0/1205770721173531/1206682403279323/f)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR fixes the `NativeClass` constructor method, namely the `constructor` doesn't have the `this` value to hand until the `JsNativeObject` is built. 

This was causes dereferencing panics since the *target* was being passed as `this`. The _target_ is the `JsValue` that is used e.g. for `new Animal`, the `JsValue` would be `Animal`. This obviously doesn't have the same Rust type as the `Self::Instance` type. 

The solution is to split the constructor into a *data* constructor and an *object* constructor.

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

This panic'd previously
```sh
jstz repl
>> const url = new URL("http://example.com/?");
>> url.searchParams.delete("param1")
>> url.search
null
```