### PR TITLE
feat(cli): completions for filename arguments

### DIFF
--- a/crates/jstz_cli/src/main.rs
+++ b/crates/jstz_cli/src/main.rs
@@ -29,7 +29,7 @@ enum Command {
     /// 🚀 Deploys a smart function to jstz
     Deploy {
         /// Function code.
-        #[arg(value_name = "CODE|PATH", default_value = None)]
+        #[arg(value_name = "CODE|PATH", default_value = None, value_hint = clap::ValueHint::FilePath)]
         code: Option<String>,
         /// Initial balance of the function.
         #[arg(short, long, default_value_t = 0)]
@@ -54,7 +54,7 @@ enum Command {
         #[arg(name = "request", short, long, default_value = "GET")]
         http_method: String,
         /// The JSON data in the request body.
-        #[arg(name = "data", short, long, default_value = None)]
+        #[arg(name = "data", short, long, default_value = None, value_hint = clap::ValueHint::FilePath)]
         json_data: Option<String>,
         /// Specifies the network from the config file, defaulting to the configured default network.
         ///  Use `dev` for the local sandbox.


### PR DESCRIPTION
# Context

`jstz cli` completions work great, but prevent the shel from completing filenames.
This PR enables filename completions for arguments that require filenames.

 **Related Tasks**: [Cli completions do not work for filenames](https://app.asana.com/0/1205770721173531/1206712599227133/f) 

# Description

Adds clap directives for completion of filenames for `jstz deploy` and `jstz run --data`

# Manually testing the PR

```bash
jstz deploy examples/<tab>
jstz run "tezos://some-function" --data somefile.j<tab>
```
