### PR TITLE
docs: fix missing quote in quick start

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -252,7 +252,7 @@ jstz bridge deposit --from bootstrap1 --to tz1Tp5wSRWiVJwLoT8WqN1yRapdq6UmdRf6W 
 After a succesful deployment, you will be able to run the smart function with the provided command to run your smart function similarly to the following:
 
 ```sh
-jstz run tezos://tz1Tp5wSRWiVJwLoT8WqN1yRapdq6UmdRf6W/ --data '{"message":"Please, give me some tez."}
+jstz run tezos://tz1Tp5wSRWiVJwLoT8WqN1yRapdq6UmdRf6W/ --data '{"message":"Please, give me some tez."}'
 ```
 
 <details>


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

Fixes missing quote in the `jstz run` command in the quick start guide

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
npm run docs:dev
```
