### PR TITLE
fix(ci): use the tezos/tezos image as the source of truth for `sandbox-params.json`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,6 @@ jobs:
       - name: Build kernel
         run: make build-kernel
 
-      - name: Upload kernel
-        id: upload-kernel
-        uses: actions/upload-artifact@v4
-        with:
-          name: jstz-kernel
-          path: target/wasm32-unknown-unknown/release/jstz_kernel.wasm
-
       - name: Lint
         run: make lint
 

--- a/.github/workflows/deploy-teztnet.yml
+++ b/.github/workflows/deploy-teztnet.yml
@@ -46,27 +46,10 @@ jobs:
             --amount 10100 \
             --network "${{ inputs.network }}"
 
-  build-kernel:
-    name: Build (Kernel)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2.7.1
-      - name: Rust setup
-        run: rustup show active-toolchain
-      - name: Build kernel
-        run: make build-kernel
-      - name: Upload kernel
-        id: upload-kernel
-        uses: actions/upload-artifact@v4
-        with:
-          name: jstz-kernel
-          path: target/wasm32-unknown-unknown/release/jstz_kernel.wasm
-
   build-docker:
     name: Build (Docker)
     uses: ./.github/workflows/docker.yml
-    needs: [download-teztnet-config, build-kernel]
+    needs: [download-teztnet-config]
     with:
       octez-tag: "${{ needs.download-teztnet-config.outputs.octez-tag }}"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,14 @@
 name: Build docker image for subsequent jobs
 
 on:
+  # For manually rebuilding the images
+  workflow_dispatch:
+    inputs:
+      octez-tag:
+        description: "tezos/tezos docker tag to be used"
+        required: true
+        type: string
+
   workflow_call:
     inputs:
       octez-tag:
@@ -23,8 +31,26 @@ env:
   DOCKER_IMAGE_BASE: trilitech
 
 jobs:
+  build-kernel:
+    name: Build (Kernel)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2.7.1
+      - name: Rust setup
+        run: rustup show active-toolchain
+      - name: Build kernel
+        run: make build-kernel
+      - name: Upload kernel
+        id: upload-kernel
+        uses: actions/upload-artifact@v4
+        with:
+          name: jstz-kernel
+          path: target/wasm32-unknown-unknown/release/jstz_kernel.wasm
+
   build-docker:
     name: Build (Docker)
+    needs: [build-kernel]
     runs-on:
       group: jstz
     permissions:

--- a/crates/jstz_cli/Dockerfile
+++ b/crates/jstz_cli/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=octez /usr/share/zcash-params /root/.zcash-params
 # Copy the jstz binary & dependencies
 COPY --from=builder /target/debug/jstz /usr/bin/jstz
 COPY --from=builder /crates/jstz_cli/jstz_kernel.wasm /usr/share/jstz/jstz_kernel.wasm
-COPY --from=builder /crates/jstz_cli/sandbox-params.json /usr/share/jstz/sandbox-params.json
 COPY --from=builder /crates/jstz_cli/sandbox.json /usr/share/jstz/sandbox.json
+# octez is the source of truth for the sandbox-params.json
+COPY --from=octez /usr/local/share/tezos/alpha-parameters/sandbox-parameters.json /usr/share/jstz/sandbox-params.json
 ENTRYPOINT [ "/usr/bin/jstz" ]


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: #465 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR modifies the Dockerfile for the CLI to use the tezos/tezos image as the source of truth
for the `sandbox-params.json` file -- this will ensure that we don't run into #465 again.

Additionally, the CI is reconfigured to permit us to manually build the docker images on request. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

CI changes aren't possible to test locally (but the changes consist of re-ordering jobs + adding a manual `workflow_dispatch` event handler)

To test the docker changes, run:
```sh
make build-cli-kernel
docker build . -f crates/jstz_cli/Dockerfile -t jstz:latest --build-arg OCTEZ_TAG=master_ddfbb8d6_20240312193411 --build-arg KERNEL_PATH=crates/jstz_cli/jstz_kernel.wasm
alias jstz="docker run --rm -v \"/tmp:/tmp\" -v \"/Users/ajob410/.jstz:/root/.jstz\" -v \"\$PWD:\$PWD\" -w \"\$PWD\" --network=host -it jstz:latest"
jstz sandbox start
```
