### PR TITLE
fix(scripts): zdotdir + config file loading

### DIFF
--- a/scripts/install-jstz-cli.sh
+++ b/scripts/install-jstz-cli.sh
@@ -7,6 +7,10 @@ network="weeklynet-2024-03-13"
 container="ghcr.io/trilitech/jstz-cli:$version"
 jstz_home="$HOME/.jstz"
 
+# ps -p filters on the parent process, -o comm= prints the command name (supressing the header)
+current_shell=$(basename "$(ps -p $$ -o comm=)")
+shell=$(basename "$SHELL")
+
 # (--rm): remove the container after it exits
 # (-v): the container mounts the following volumes:
 #  - /tmp for temporary files
@@ -21,7 +25,7 @@ jstz_download() {
     # Check if Docker is installed
     if ! command -v docker &> /dev/null; then
         echo "Docker is not installed. Please install Docker and try again."
-        exit 1
+        return 1
     fi
 
     # Pull the Docker CLI container from GitHub Container Registry
@@ -72,22 +76,19 @@ EOF
 
     echo "Configuring \`jstz\` alias..."
 
-    shell=$(basename "$SHELL")
-    case "$shell" in
-        "bash")
-            shellrc="$HOME/.bashrc"
-            ;;
-        "zsh")
-            shellrc="$HOME/.zshrc"
-            ;;
-        *)
-            cat 1>&2 << EOF
-Unsupported shell: $shell. 
-Please manually add the alias to your shell's configuration file.
-    $shell_alias
-EOF
-            exit 1
-    esac
+    echo "SHELL: $shell"
+    echo "Detected shell: $current_shell"
+
+    if [[ $shell == "bash" ]]; then
+        shellrc="$HOME/.bashrc"
+    elif [[ $shell == "zsh" ]]; then
+        # Respect the ZDOTDIR variable if set, defaulting to $HOME if not
+        shellrc="${ZDOTDIR:-$HOME}/.zshrc"
+    else
+        echo >&2 "Unsupported shell: $shell. Please manually add the following alias to your shell's configuration file."
+        echo >&2 "    $shell_alias"
+        return 1
+    fi
 
     if ! [ -w "$shellrc" ]; then
         echo "Warning: $shellrc is not writable. Please manually add the following alias to your shell's configuration file:"
@@ -95,6 +96,7 @@ EOF
 
         echo "Once you have added the alias, run the following command to reload the configuration file in your default shell:"
         echo "    source $shellrc"
+        return 1
     fi
 
     if grep -q "alias jstz=" "$shellrc"; then
@@ -105,12 +107,20 @@ $shell_alias" "$shellrc"
         echo "$shell_alias" >> "$shellrc"
         echo "Alias added to $shellrc."
     fi
+    echo "$shell_alias"
 
     # shellcheck disable=SC1090
     # `$shellrc` can only be determined at runtime, so we need to disable the warning.
     # 
     # Reload the shell configuration file to apply the changes 
-    . "$shellrc"
+    if [[ "$shell" == "$current_shell" ]]; then
+        echo "Reloading shell configuration file: $shellrc"
+        . "$shellrc"
+    else
+        echo "The current shell session does not match the default shell. Configuration file not reloaded."
+        echo "Please run the following command from your default shell to reload the configuration file:"
+        echo "    source $shellrc"
+    fi
 }
 
 do_install() {


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
This PR addresses issue #472 and #473. It respects ZDOTDIR variable if set and only reloads the configuration file if the shell is matching SHELL value, in order to not break previous prompt.
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
run the install script
<!-- Describe how reviewers and approvers can test this PR. -->
