### PR TITLE
feat(cli): improve sandbox error message

### DIFF
--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -343,6 +343,10 @@ impl Config {
     }
 
     pub fn jstz_client(&self, network_name: &Option<NetworkName>) -> Result<JstzClient> {
+        if let Some(NetworkName::Dev) = network_name {
+            self.sandbox()?;
+        };
+
         let network = self.network(network_name)?;
 
         Ok(JstzClient::new(network.jstz_node_endpoint.clone()))


### PR DESCRIPTION
# Context

Improve the error message
[Task](https://app.asana.com/0/1205770721173531/1206703424903101/f)

# Description

improve the error message that gets thrown when sandbox isn't running

# Manually testing the PR

Run:
```
jstz account balance -n dev
```
Before:
```
✕  ERROR  error sending request for url (http://127.0.0.1:8933/accounts/tz1dbGzJfjYFSjX8umiRZ2fmsAQsk8XMH1E9/balance): error trying to connect: tcp connect error: Connection refused (os error 61)
```
After:
```
✕  ERROR  The sandbox is not running. Please run `jstz sandbox start`.
```