### PR TITLE
Sandbox: improve startup robustness

### DIFF
--- a/crates/jstz_rollup/src/rollup.rs
+++ b/crates/jstz_rollup/src/rollup.rs
@@ -111,6 +111,13 @@ impl JstzRollup {
         )?;
 
         // 2. Run the rollup node (configuring the kernel log file)
+        let kernel_log = logs_dir.join("kernel.log");
+        // ensure the log exists
+        let _ = fs::File::options()
+            .append(true)
+            .create(true)
+            .open(&kernel_log)?;
+
         rollup_node.run(
             addr,
             port,
@@ -120,7 +127,7 @@ impl JstzRollup {
             &[
                 "--log-kernel-debug",
                 "--log-kernel-debug-file",
-                logs_dir.join("kernel.log").to_str().expect("Invalid path"),
+                kernel_log.to_str().expect("Invalid path"),
             ],
         )
     }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,7 +124,7 @@ You can start the sandbox with:
 
 ```sh
 make build-cli-kernel
-cargo run --bin jstz -- sandbox start
+PATH=.:$PATH cargo run --bin jstz -- sandbox start
 ```
 
 This will initially run `octez-node` and initialize `octez-client`. Once the client is initialized, the `jstz_kernel` and `jstz_bridge` is originated, a `octez-smart-rollup-node` and `jstz-node` is spun up.


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->
Prevents a few different cryptic errors when starting up (all of which appear as 'file not found'), namely:

- octez binaries can't be found, despite having been copied into `jstz` directory - they have to be in `PATH`
- kernel.log file not created, which causes the `TailedFile::init` to fall over. Ensure we create it earlier in the process

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
delete your `~/.jstz` folder, and try starting the sandbox with/without this change