### PR TITLE
fix(sandbox): spinner should spin continuously

### DIFF
--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -519,7 +519,6 @@ fn run_progress_bar(cfg: &Config, mut child: Option<Child>) -> Result<()> {
                 if let Some(matched) = captures.get(1) {
                     if let Ok(num) = matched.as_str().parse::<u32>() {
                         progress = num;
-                        progress_bar.set_position(progress.into());
                     }
                 }
             }
@@ -539,6 +538,7 @@ fn run_progress_bar(cfg: &Config, mut child: Option<Child>) -> Result<()> {
             }
         }
 
+        progress_bar.set_position(progress.into());
         thread::sleep(Duration::from_millis(100));
     }
 


### PR DESCRIPTION
# Manually testing

`jstz sandbox start`. Observe that, with the patch, the left hand 'spinner icon' is never stuck