### PR TITLE
Set instruction limit

### DIFF
--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -23,7 +23,9 @@ use crate::{
     utils::{read_file_or_input_or_piped, AddressOrAlias},
 };
 
-pub const DEFAULT_GAS_LIMIT: u32 = 100_000;
+// This was measured by running the benchmark.js,
+// where the FA2 transfer function was called 1000 times.
+pub const DEFAULT_GAS_LIMIT: u32 = 550000;
 
 pub async fn exec(
     url: String,

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -428,8 +428,7 @@ pub mod run {
 
         debug_msg!(
             hrt,
-            "🚀 Smart function executed successfully with value: {:?}\n",
-            result
+            "🚀 Smart function executed successfully with value: {:?} (in {:?} instructions)\n", result, gas_limit - rt.instructions_remaining()
         );
 
         // 6. Serialize response

--- a/examples/benchmark.js
+++ b/examples/benchmark.js
@@ -1,0 +1,56 @@
+async function fa2_balance_of(fa2, minter, token_id) {
+  const balance_request = [{ owner: minter, token_id }];
+
+  const encodedRequests = btoa(JSON.stringify(balance_request));
+
+  const response = await fetch(
+    new Request(`tezos://${fa2}/balance_of?requests=${encodedRequests}`),
+  );
+  const balances = await response.json();
+  console.log(
+    `Address ${balances[0].request.owner} has ${balances[0].balance}`,
+  );
+}
+
+async function handler(request) {
+  const url = new URL(request.url);
+  const n = Number(url.searchParams.get("n"));
+  const fa2 = url.searchParams.get("fa2");
+  const minter = Ledger.selfAddress;
+  const token_id = 1;
+
+  console.log(`minting ${n} tokens to ${minter}`);
+
+  const tokens = [{ token_id, owner: minter, amount: n }];
+
+  await SmartFunction.call(
+    new Request(`tezos://${fa2}/mint_new`, {
+      method: "POST",
+      body: JSON.stringify(tokens),
+    }),
+  );
+
+  await fa2_balance_of(fa2, minter, token_id);
+
+  const transfers = [
+    {
+      from: Ledger.selfAddress,
+      transfers: [{ to: fa2, token_id, amount: 1 }],
+    },
+  ];
+
+  for (let i = 0; i < n; i++) {
+    await SmartFunction.call(
+      new Request(`tezos://${fa2}/transfer`, {
+        method: "POST",
+        body: JSON.stringify(transfers),
+      }),
+    );
+  }
+
+  await fa2_balance_of(fa2, minter, token_id);
+
+  return new Response();
+}
+
+export default handler;


### PR DESCRIPTION
# Context

please check the google doc [here](https://docs.google.com/document/d/1xOllQhKrkHBpx3acthXUZ1Qc8uq4Jyn7Utgjg66zKi4/edit)

[asana task](https://app.asana.com/0/1205770721173531/1207085786191010/f) 

# Description

Tested the instruction limit required to run `benchmark.js` where n is the number of times fa2 token is transferred.
Set the instruction limit to `550000` based on the following result:


<b style="font-weight:normal;" id="docs-internal-guid-fb5cbdf7-7fff-9b87-881f-c6f6f11caca1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Result:</span></p><br /><br /><div dir="ltr" style="margin-left:0pt;" align="left">
n | Instruction count
-- | --
100 | 54843
200 | 108643
300 | 162443
400 | 216243
500 | 270043
1000 | 539043

</div></b>

# Manually testing the PR

1. deploy the fa2 contract 
2. deploy the benchmark contract
2. run the benchmark contract providing the parameter `n` and `fa2` 
e.g.) `jstz run "tezos://tz1ZhgCYXb4cLMnd46eRgHXVK14rM7mnQECC/?n=1000&fa2=tz1RWdh69PibVpbpLPi71sTGcHdtajxzmdfY" --trace --gas-limit 539043`
