### PR TITLE
fix(deps): remove blst from crate tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Lint
         run: make lint
 
+      - name: Prevent blst
+        run: sh -c '[ -z "$(cargo tree | grep blst)" ]'
+
       - name: Build all packages
         run: cargo build
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,19 +539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blst"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a30d0edd9dd1c60ddb42b80341c7852f6f985279a5c1a83659dcb65899dec99"
-dependencies = [
- "cc",
- "glob",
- "threadpool",
- "which",
- "zeroize",
-]
-
-[[package]]
 name = "boa_ast"
 version = "0.17.0"
 source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#78c8540eb0167abd62975f47d40aa55a7bbcf5d0"
@@ -1681,12 +1668,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -4344,7 +4325,6 @@ checksum = "284fa6f4be10eff67ca5b2f9e8ec9544be81a07223f6a4c8d3a49a13aecce768"
 dependencies = [
  "anyhow",
  "base58",
- "blst",
  "byteorder 1.5.0",
  "cryptoxide",
  "ed25519-dalek",
@@ -4418,15 +4398,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]
@@ -4965,18 +4936,6 @@ name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "widestring"

--- a/crates/jstz_core/Cargo.toml
+++ b/crates/jstz_core/Cargo.toml
@@ -14,7 +14,7 @@ description.workspace = true
 boa_engine = { version = "0.17.0", features = ["fuzz"] }
 boa_gc = "0.17.0"
 tezos-smart-rollup-host.workspace = true
-tezos-smart-rollup = "0.2.2"
+tezos-smart-rollup.workspace = true
 getrandom = { version = "0.2.12", features = ["custom"] }
 derive_more = "0.99.17"
 bincode = "1.3.3"
@@ -29,4 +29,4 @@ expect-test = "1.4.1"
 tokio = { version = "1.36.0", features = ["full"] }
 jstz_proto.workspace = true
 jstz_crypto.workspace = true
-tezos-smart-rollup-mock = "0.2.2"
+tezos-smart-rollup-mock.workspace = true


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->
Remove blst from crate graph

# Description

<!-- Describe your changes in detail. -->
Prevent `blst` coming back into the crate tree, as this breaks building jstz for riscv on mac.

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
`cargo tree | grep blst`

See https://github.com/trilitech/jstz/actions/runs/9080566889/job/24952362135 for an example of the new check failing