### PR TITLE
feat(kernel): external messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,6 +2330,7 @@ dependencies = [
  "actix-web",
  "actix-web-lab",
  "anyhow",
+ "base64 0.13.1",
  "bincode",
  "clap 4.4.18",
  "dirs",
@@ -2348,6 +2349,10 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tezos-smart-rollup",
+ "tezos-smart-rollup-encoding",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2796,6 +2801,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "tezos-smart-rollup-encoding",
 ]
 
 [[package]]

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -39,6 +39,11 @@ r2d2 = {version = "0.8", optional = true}
 r2d2_sqlite = {version = "0.22", optional = true}
 rusqlite = {version = "0.29", optional = true}
 actix-cors = "0.6.5"
+base64 = "0.13.1"
+tezos-smart-rollup.workspace = true
+tezos-smart-rollup-encoding.workspace = true
+tezos_data_encoding = "0.5.2"
+tezos_crypto_rs.workspace = true
 
 [[bin]]
 name = "jstz-node"

--- a/crates/octez/Cargo.toml
+++ b/crates/octez/Cargo.toml
@@ -20,3 +20,4 @@ reqwest = { version = "0.11.24", features = ["json"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.108"
 signal-hook = "0.3.17"
+tezos-smart-rollup-encoding.workspace = true


### PR DESCRIPTION
# Context
https://app.asana.com/0/1205770721173533/1207223543435817
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
When a rollup is deployed on a network where other rollups are deployed, such as ghostnet, it receives external messages from all rollups. In the current implementation, this results in "Failed to parse external message error". This PR add external message frame where it is possible to specify the smart rollup address and thus only consume the messages directed at jstz.

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
Start sandbox, deploy and run a smart function.
<!-- Describe how reviewers and approvers can test this PR. -->
