### PR TITLE
feat(kernel): hide 'static requirements

### DIFF
--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -17,7 +17,7 @@ fn read_ticketer(rt: &impl Runtime) -> Option<ContractKt1Hash> {
     Storage::get(rt, &TICKETER).ok()?
 }
 
-fn handle_message(hrt: &mut (impl Runtime + 'static), message: Message) -> Result<()> {
+fn handle_message(hrt: &mut impl Runtime, message: Message) -> Result<()> {
     let mut tx = Transaction::default();
     tx.begin();
 
@@ -38,7 +38,7 @@ fn handle_message(hrt: &mut (impl Runtime + 'static), message: Message) -> Resul
 }
 
 // kernel entry
-pub fn entry(rt: &mut (impl Runtime + 'static)) {
+pub fn entry(rt: &mut impl Runtime) {
     let ticketer = read_ticketer(rt);
 
     if let Some(message) = read_message(rt, ticketer.as_ref()) {

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -10,7 +10,7 @@ pub mod deposit;
 pub mod smart_function;
 
 fn execute_operation_inner(
-    hrt: &mut (impl HostRuntime + 'static),
+    hrt: &mut impl HostRuntime,
     tx: &mut Transaction,
     signed_operation: SignedOperation,
 ) -> Result<receipt::Content> {
@@ -54,7 +54,7 @@ pub fn execute_external_operation(
 }
 
 pub fn execute_operation(
-    hrt: &mut (impl HostRuntime + 'static),
+    hrt: &mut impl HostRuntime,
     tx: &mut Transaction,
     signed_operation: SignedOperation,
 ) -> Receipt {

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -370,7 +370,7 @@ pub mod run {
     }
 
     pub fn execute(
-        hrt: &mut (impl HostRuntime + 'static),
+        hrt: &mut impl HostRuntime,
         tx: &mut Transaction,
         source: &Address,
         run: operation::RunFunction,


### PR DESCRIPTION
# What

Hide `'static` requirements from top-level entry function

# Why

Significantly simplifies integration of jstz with parts of the sdk/riscv work. The requirement is used by jstz to play fast & loose with lifetimes internally, and is effectively an implementation detail which can be hidden away.