### PR TITLE
feat(jstzd): copy built kernel files when KERNEL_DEST_DIR is set

### DIFF
--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -64,6 +64,33 @@ fn main() {
         "cargo:warning=Build script output directory: {}",
         out_dir.display()
     );
+    if let Ok(p) = env::var("KERNEL_DEST_DIR") {
+        println!(
+            "cargo:warning=Copying content in output directory to: {}",
+            p
+        );
+        fs::create_dir_all(&p).unwrap_or_else(|e| {
+            panic!("Failed to create destination directory '{}': {:?}", &p, e)
+        });
+        copy_dir_all(out_dir, &p).unwrap_or_else(|e| {
+            panic!("Failed to copy kernel files to '{}': {:?}", &p, e)
+        });
+    }
+}
+
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry_ in fs::read_dir(src)? {
+        let entry = entry_?;
+        let src_path = entry.path();
+        let dst_path = dst.as_ref().join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_all(src_path, dst_path)?;
+        } else {
+            fs::copy(src_path, dst_path)?;
+        }
+    }
+    Ok(())
 }
 
 /// Builds the kernel installer and generates preimages


### PR DESCRIPTION
# Context

Part of JSTZ-277.
[JSTZ-277](https://linear.app/tezos/issue/JSTZ-277/make-built-kernel-files-easily-accessible)

Part of [JSTZ-273](https://linear.app/tezos/issue/JSTZ-273/ship-jstzd-in-a-container).

# Description

Currently building the kernel wasm file into the installer file and preimages is part of the build process. These files are kept somewhere in the build environment and there is no easy way to locate them. This PR therefore introduces an environment variable `KERNEL_DEST_DIR` that tells the build code to copy the built kernel files to a specified location when it is set during build time. One such use case is that when building an image for jstzd, we want to collect these kernel files after a jstzd build completes and port them to the actual environment where jstzd will be executed.

# Manually testing the PR

Since `build.rs` cannot be tested with unit tests, these changes were tested manually:
```sh
$ KERNEL_DEST_DIR=/tmp/foo cargo build --bin jstzd --release
...
   Compiling jstzd v0.1.0-alpha.0 (/code/crates/jstzd)
   Compiling octez v0.1.0-alpha.0 (/code/crates/octez)
   Compiling jstz_node v0.1.0-alpha.0 (/code/crates/jstz_node)
warning: jstzd@0.1.0-alpha.0: Build script output directory: /code/target/release/build/jstzd-cb92e6b31c692d92/out
warning: jstzd@0.1.0-alpha.0: Copying content in output directory to: /tmp/foo
    Finished `release` profile [optimized] target(s) in 4m 52s
$ ls /tmp/foo
jstz_rollup_path.rs   kernel_installer.hex  parameters_ty.json    preimages
```
The warning line `Copying content in output directory to` was indeed printed with the specified path and the files were indeed copied to the destination.
