### PR TITLE
ci: build multiplatform images

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -1,0 +1,89 @@
+name: Build docker image for jstz binaries
+inputs:
+  platform:
+    description: Platform that the binary can run on, e.g. linux, macos
+    required: true
+  arch:
+    description: Architecture of CPU that the binary can run on, e.g. arm64, amd64
+    required: true
+  repo_token:
+    description: API token that gives access to manage the target repo
+    required: true
+  octez-tag:
+    description: "tezos/tezos docker tag to be used"
+    required: true
+  docker_registry:
+    description: Docker registry
+    required: true
+  docker_registry_username:
+    description: Docker registry username
+    required: true
+  docker_registry_password:
+    description: Docker registry password
+    required: true
+  docker_image_base:
+    description: Docker image base
+    required: true
+  image:
+    description: Image
+    required: true
+  dockerfile:
+    description: Dockerfile
+    required: true
+  kernel_artefact_name:
+    description: Kernel artefact name
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - run: echo "${{ runner.temp }}"
+      shell: bash
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.docker_registry }}
+        username: ${{ inputs.docker_registry_username }}
+        password: ${{ inputs.docker_registry_password }}
+    - name: Download jstz-kernel artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.kernel_artefact_name }}
+        path: jstz_kernel
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ inputs.docker_registry }}/${{ inputs.docker_image_base }}/${{ inputs.image }}
+        tags: |
+          type=ref,event=tag
+          {{sha}}
+    - name: Build and push Docker image
+      id: build-image
+      uses: docker/build-push-action@v6.3.0
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        build-args: |
+          OCTEZ_TAG=${{ inputs.octez-tag }}
+          KERNEL_PATH=./jstz_kernel/jstz_kernel.wasm
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: ${{ inputs.platform }}
+        outputs: type=image,"name=${{ inputs.docker_registry }}/${{ inputs.docker_image_base }}/${{ inputs.image }}",push-by-digest=true,name-canonical=true,push=true
+    - name: Export digest
+      shell: bash
+      run: |
+        mkdir -p ${{ runner.temp }}/digests/${{ inputs.image }}
+        digest="${{ steps.build-image.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${{ inputs.image }}/${digest#sha256:}"
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-${{ inputs.image }}-${{ inputs.platform }}-${{ inputs.arch }}
+        path: ${{ runner.temp }}/digests/${{ inputs.image }}/*
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -1,0 +1,117 @@
+name: Build multiplatform docker image
+
+on:
+  workflow_call:
+    inputs:
+      octez-tag:
+        description: "tezos/tezos docker tag to be used"
+        required: true
+        type: string
+      docker_registry:
+        description: Docker registry
+        required: true
+        type: string
+      docker_image_base:
+        description: Docker image base
+        required: true
+        type: string
+      image:
+        description: Image
+        required: true
+        type: string
+      dockerfile:
+        description: Dockerfile
+        required: true
+        type: string
+      kernel_artifact_name:
+        description: Kernel artifact name
+        required: true
+        type: string
+    outputs:
+      tag:
+        description: "docker image tag"
+        value: ${{ jobs.merge.outputs.tag }}
+
+jobs:
+  build-docker-arm64:
+    name: Build (Docker arm64)
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Build
+        uses: jstz-dev/jstz/.github/actions/build-docker-image@main
+        with:
+          platform: linux
+          arch: arm64
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          octez-tag: ${{ inputs.octez-tag }}
+          docker_registry: ${{ inputs.docker_registry }}
+          docker_registry_username: ${{ github.actor }}
+          docker_registry_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_image_base: ${{ inputs.docker_image_base }}
+          image: ${{ inputs.image }}
+          dockerfile: ${{ inputs.dockerfile }}
+          kernel_artefact_name: ${{ inputs.kernel_artifact_name }}
+  build-docker-amd64:
+    name: Build (Docker amd64)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Build
+        uses: jstz-dev/jstz/.github/actions/build-docker-image@main
+        with:
+          platform: linux
+          arch: amd64
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          octez-tag: ${{ inputs.octez-tag }}
+          docker_registry: ${{ inputs.docker_registry }}
+          docker_registry_username: ${{ github.actor }}
+          docker_registry_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_image_base: ${{ inputs.docker_image_base }}
+          image: ${{ inputs.image }}
+          dockerfile: ${{ inputs.dockerfile }}
+          kernel_artefact_name: ${{ inputs.kernel_artifact_name }}
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build-docker-amd64
+      - build-docker-arm64
+    outputs:
+      tag: ${{ fromJson(steps.meta.outputs.json).tags[0] }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/${{ inputs.image }}
+          pattern: digests-${{ inputs.image }}-*
+          merge-multiple: true
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ inputs.docker_registry }}/${{ inputs.docker_image_base }}/${{ inputs.image }}
+          tags: |
+            type=ref,event=tag
+            {{sha}}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests/${{ inputs.image }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}') \
+            $(printf '${{ inputs.docker_registry }}/${{ inputs.docker_image_base }}/${{ inputs.image }}@sha256:%s ' *)
+      - name: Inspect image
+        id: inspect-image
+        run: |
+          docker buildx imagetools inspect "${{ fromJson(steps.meta.outputs.json).tags[0] }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,20 +22,16 @@ on:
     outputs:
       jstz-cli:
         description: "jstz docker image tag"
-        value: ${{ jobs.build-docker.outputs.jstz-cli }}
+        value: ${{ jobs.build-image.outputs.tag }}
       jstz-rollup:
         description: "jstz-rollup docker image tag"
-        value: ${{ jobs.build-docker.outputs.jstz-rollup }}
+        value: ${{ jobs.build-image.outputs.tag }}
       jstz-node:
         description: "jstz-node docker image tag"
-        value: ${{ jobs.build-docker.outputs.jstz-node }}
+        value: ${{ jobs.build-image.outputs.tag }}
       jstzd:
         description: "jstzd docker image tag"
-        value: ${{ jobs.build-docker.outputs.jstzd }}
-
-env:
-  DOCKER_REGISTRY: ghcr.io
-  DOCKER_IMAGE_BASE: jstz-dev/jstz
+        value: ${{ jobs.build-image.outputs.tag }}
 
 jobs:
   build-kernel:
@@ -56,86 +52,26 @@ jobs:
         with:
           name: jstz-kernel
           path: result/lib/jstz_kernel.wasm
-
-  build-docker:
-    name: Build (Docker)
+  build-image:
+    name: Build image
     needs: [build-kernel]
-    runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      jstz-cli: ${{ steps.jstz-cli-tag.outputs.tag || '' }}
-      jstz-rollup: ${{ steps.jstz-rollup-tag.outputs.tag || '' }}
-      jstz-node: ${{ steps.jstz-node-tag.outputs.tag || '' }}
-      jstzd: ${{ steps.jstzd-tag.outputs.tag || '' }}
     strategy:
       matrix:
         include:
-          - image: jstzd
-            dockerfile: ./crates/jstzd/Dockerfile
-            platforms: linux/arm64
-          - image: jstz-cli
-            dockerfile: ./crates/jstz_cli/Dockerfile
-            platforms: linux/arm64
-          - image: jstz-node
-            dockerfile: ./crates/jstz_node/Dockerfile
-            platforms: linux/arm64
           - image: jstz-rollup
             dockerfile: ./crates/jstz_rollup/Dockerfile
-            platforms: linux/arm64
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Docker registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download jstz-kernel artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: jstz-kernel
-          path: jstz_kernel
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_BASE }}/${{ matrix.image }}
-          tags: |
-            type=ref,event=tag
-            {{sha}}
-      - # Extract tags for jstz
-        run: echo "tag=${{ fromJson(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
-        id: jstz-cli-tag
-        if: matrix.image == 'jstz-cli'
-      - # Extract tags for jstz-node
-        run: echo "tag=${{ fromJson(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
-        id: jstz-node-tag
-        if: matrix.image == 'jstz-node'
-      - # Extract tags for jstz-rollup
-        run: echo "tag=${{ fromJson(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
-        id: jstz-rollup-tag
-        if: matrix.image == 'jstz-rollup'
-      - # Extract tags for jstzd
-        run: echo "tag=${{ fromJson(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
-        id: jstzd-tag
-        if: matrix.image == 'jstzd'
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6.3.0
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          build-args: |
-            OCTEZ_TAG=${{ inputs.octez-tag }}
-            KERNEL_PATH=./jstz_kernel/jstz_kernel.wasm
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platforms }}
+          - image: jstzd
+            dockerfile: ./crates/jstzd/Dockerfile
+          - image: jstz-cli
+            dockerfile: ./crates/jstz_cli/Dockerfile
+          - image: jstz-node
+            dockerfile: ./crates/jstz_node/Dockerfile
+    uses: jstz-dev/jstz/.github/workflows/docker-multiplatform.yml@main
+    with:
+      octez-tag: ${{ inputs.octez-tag }}
+      docker_registry: ghcr.io
+      docker_image_base: jstz-dev/jstz
+      image: ${{ matrix.image }}
+      dockerfile: ${{ matrix.dockerfile }}
+      kernel_artifact_name: jstz-kernel
+    secrets: inherit


### PR DESCRIPTION
# Context

Part of JSTZ-286.
[JSTZ-286](https://linear.app/tezos/issue/JSTZ-286/build-multiplatform-images)

# Description

Revise the image build pipeline so that all images have multiplatform support without cross-compilation. Essentially, each docker file is used to build images on multiple machines with different architectures and the image digests are merged afterwards. 

# Manually testing the PR

[Test build](https://github.com/jstz-dev/jstz/actions/runs/12941205489)
