### PR TITLE
refactor(kernel): asynchronify kernel handle message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,6 +2965,7 @@ version = "0.1.1-alpha.1"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "boa_engine",
+ "futures",
  "hex",
  "http 1.1.0",
  "http-serde",

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "lib"]
 bincode.workspace = true
 boa_engine.workspace = true
 hex.workspace = true
+futures.workspace = true
 http-serde.workspace = true
 http.workspace = true
 jstz_api = { path = "../jstz_api" }

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -1,6 +1,6 @@
 use jstz_core::{host::WriteDebug, BinEncodable};
 use jstz_proto::context::account::Address;
-use jstz_proto::operation::{external::Deposit, ExternalOperation, SignedOperation};
+use jstz_proto::operation::{internal::Deposit, InternalOperation, SignedOperation};
 use num_traits::ToPrimitive;
 use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
 use tezos_smart_rollup::michelson::ticket::FA2_1Ticket;
@@ -17,7 +17,7 @@ pub use tezos_smart_rollup::{
 use crate::parsing::try_parse_fa_deposit;
 
 pub type ExternalMessage = SignedOperation;
-pub type InternalMessage = ExternalOperation;
+pub type InternalMessage = InternalOperation;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Message {
@@ -224,12 +224,15 @@ fn read_external_message(
 #[cfg(test)]
 mod test {
     use jstz_core::host::WriteDebug;
-    use jstz_crypto::hash::Hash;
-    use jstz_crypto::smart_function_hash::SmartFunctionHash;
-    use jstz_mock::message::native_deposit::MockNativeDeposit;
-    use jstz_mock::{host::JstzMockHost, message::fa_deposit::MockFaDeposit};
-    use jstz_proto::context::account::{Address, Addressable};
-    use jstz_proto::operation::{external, Content, ExternalOperation};
+    use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
+    use jstz_mock::{
+        host::JstzMockHost,
+        message::{fa_deposit::MockFaDeposit, native_deposit::MockNativeDeposit},
+    };
+    use jstz_proto::{
+        context::account::{Address, Addressable},
+        operation::{internal, Content, InternalOperation},
+    };
     use tezos_crypto_rs::hash::{ContractKt1Hash, HashTrait, SmartRollupHash};
     use tezos_smart_rollup::types::SmartRollupAddress;
 
@@ -257,7 +260,7 @@ mod test {
         let deposit = MockNativeDeposit::default();
         let ticketer = host.get_ticketer();
         host.add_internal_message(&deposit);
-        if let Message::Internal(InternalMessage::Deposit(external::Deposit {
+        if let Message::Internal(InternalMessage::Deposit(internal::Deposit {
             amount,
             receiver,
             ..
@@ -317,7 +320,7 @@ mod test {
         let ticketer = host.get_ticketer();
         host.add_internal_message(&fa_deposit);
 
-        if let Message::Internal(InternalMessage::FaDeposit(external::FaDeposit {
+        if let Message::Internal(InternalMessage::FaDeposit(internal::FaDeposit {
             amount,
             receiver,
             proxy_smart_function,
@@ -399,7 +402,7 @@ mod test {
         };
 
         assert!(
-            matches!(transfer, ExternalOperation::Deposit(..)),
+            matches!(transfer, InternalOperation::Deposit(..)),
             "Expected Deposit"
         );
     }

--- a/crates/jstz_kernel/src/parsing.rs
+++ b/crates/jstz_kernel/src/parsing.rs
@@ -1,6 +1,6 @@
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
-use jstz_proto::operation::external::FaDeposit;
+use jstz_proto::operation::internal::FaDeposit;
 use jstz_proto::{context::account::Address, Result};
 use num_traits::ToPrimitive;
 use tezos_smart_rollup::michelson::{ticket::FA2_1Ticket, MichelsonContract};
@@ -57,7 +57,7 @@ mod test {
     use jstz_crypto::smart_function_hash::SmartFunctionHash;
     use jstz_proto::{
         context::account::{Address, Addressable},
-        operation::external::FaDeposit,
+        operation::internal::FaDeposit,
     };
     use tezos_smart_rollup::{
         michelson::{

--- a/crates/jstz_node/src/sequencer/inbox/parsing.rs
+++ b/crates/jstz_node/src/sequencer/inbox/parsing.rs
@@ -6,8 +6,10 @@
 use jstz_core::{host::WriteDebug, BinEncodable};
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
-use jstz_proto::operation::external::FaDeposit;
-use jstz_proto::operation::{external::Deposit, ExternalOperation, SignedOperation};
+use jstz_proto::operation::{
+    internal::{Deposit, FaDeposit},
+    InternalOperation, SignedOperation,
+};
 use jstz_proto::{context::account::Address, Result};
 use num_traits::ToPrimitive;
 use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
@@ -23,7 +25,7 @@ pub use tezos_smart_rollup::{
 };
 
 pub type ExternalMessage = SignedOperation;
-pub type InternalMessage = ExternalOperation;
+pub type InternalMessage = InternalOperation;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Message {
@@ -267,8 +269,8 @@ mod test {
     use jstz_core::host::WriteDebug;
     use jstz_crypto::smart_function_hash::SmartFunctionHash;
     use jstz_proto::context::account::{Address, Addressable};
-    use jstz_proto::operation::external::FaDeposit;
-    use jstz_proto::operation::{Content, ExternalOperation};
+    use jstz_proto::operation::internal::FaDeposit;
+    use jstz_proto::operation::{Content, InternalOperation};
     use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
     use tezos_smart_rollup::michelson::ticket::{FA2_1Ticket, Ticket};
     use tezos_smart_rollup::michelson::{
@@ -337,7 +339,7 @@ mod test {
         };
 
         assert!(
-            matches!(transfer, ExternalOperation::Deposit(..)),
+            matches!(transfer, InternalOperation::Deposit(..)),
             "Expected Deposit"
         );
     }

--- a/crates/jstz_proto/src/executor/deposit.rs
+++ b/crates/jstz_proto/src/executor/deposit.rs
@@ -3,7 +3,7 @@ use jstz_crypto::hash::Blake2b;
 
 use crate::{
     context::account::Account,
-    operation::external::Deposit,
+    operation::internal::Deposit,
     receipt::{DepositReceipt, Receipt},
 };
 
@@ -36,7 +36,7 @@ mod test {
 
     use crate::{
         context::account::Address,
-        operation::external::Deposit,
+        operation::internal::Deposit,
         receipt::{DepositReceipt, ReceiptContent, ReceiptResult},
     };
 

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     operation::{
-        self, Content, ExternalOperation, Operation, OperationHash, SignedOperation,
+        self, Content, InternalOperation, Operation, OperationHash, SignedOperation,
     },
     receipt::{self, Receipt},
     Error, Result,
@@ -64,15 +64,15 @@ fn execute_operation_inner(
     }
 }
 
-pub fn execute_external_operation(
+pub async fn execute_internal_operation(
     hrt: &mut impl HostRuntime,
     tx: &mut Transaction,
-    external_operation: ExternalOperation,
+    internal_operation: InternalOperation,
 ) -> Receipt {
-    match external_operation {
-        ExternalOperation::Deposit(deposit) => deposit::execute(hrt, tx, deposit),
-        ExternalOperation::FaDeposit(fa_deposit) => {
-            fa_deposit::execute(hrt, tx, fa_deposit)
+    match internal_operation {
+        InternalOperation::Deposit(deposit) => deposit::execute(hrt, tx, deposit),
+        InternalOperation::FaDeposit(fa_deposit) => {
+            fa_deposit::execute(hrt, tx, fa_deposit).await
         }
     }
 }

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -240,7 +240,7 @@ impl SignedOperation {
     }
 }
 
-pub mod external {
+pub mod internal {
     use tezos_smart_rollup::michelson::ticket::TicketHash;
 
     use super::*;
@@ -293,9 +293,9 @@ pub mod external {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum ExternalOperation {
-    Deposit(external::Deposit),
-    FaDeposit(external::FaDeposit),
+pub enum InternalOperation {
+    Deposit(internal::Deposit),
+    FaDeposit(internal::FaDeposit),
 }
 
 pub mod openapi {


### PR DESCRIPTION
# Context
Required for async kernel.

Reduce review burden by asynchronifying kernel `handle_message` and its dependencies only

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Make kernel `handle_message` async
* Remove inner temporary `block_on`s
* Rename `ExternalOperation` to `InternalOperation` to align with tezos [internal message](https://docs.tezos.com/architecture/smart-rollups#rollup-inbox) terminology & semantics. 
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make build && make test`
<!-- Describe how reviewers and approvers can test this PR. -->
