### PR TITLE
fix(cli): revise config file helper function

### DIFF
--- a/crates/jstz_cli/src/sandbox/container.rs
+++ b/crates/jstz_cli/src/sandbox/container.rs
@@ -187,7 +187,8 @@ async fn create_config_file_and_client_dir() -> Result<(PathBuf, PathBuf)> {
     let config_file_path = NamedTempFile::new()
         .context("Failed to create a file as the config file")?
         .into_temp_path()
-        .to_path_buf();
+        .keep()
+        .context("Failed to keep the config file path")?;
     fs::File::create(&config_file_path)
         .await
         .context("Failed to create config file")?


### PR DESCRIPTION
# Context

This test case `jstz_cli sandbox::container::tests::create_config_file_and_client_dir` sometimes fail randomly in CI, which is quite annoying.

The error message is always
```
called `Result::unwrap()` on an `Err` value: Error("EOF while parsing a value", line: 1, column: 0)
```

# Description

Updated the helper function `create_config_file_and_client_dir` such that it correctly converts the temporary config file into a non-temporary path.

According to the [doc](https://docs.rs/tempfile/latest/tempfile/struct.TempPath.html#method.keep), this method `keep`
> Keep the temporary file from being deleted. This function will turn the temporary file into a non-temporary file without moving it.

# Manually testing the PR

Unit tests still work. 
