### PR TITLE
refactor(kernel): implement parse_inbox_message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,6 +2937,7 @@ version = "0.1.1-alpha.1"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "boa_engine",
+ "hex",
  "http 1.1.0",
  "http-serde",
  "jstz_api",

--- a/crates/jstz_core/src/host.rs
+++ b/crates/jstz_core/src/host.rs
@@ -10,6 +10,17 @@ use tezos_smart_rollup_host::{
     runtime::ValueType,
 };
 
+/// A trait that provides a simple interface for debug logging, independent of the HostRuntime implementation
+pub trait WriteDebug {
+    fn write_debug(&self, msg: &str);
+}
+
+impl<T: HostRuntime> WriteDebug for T {
+    fn write_debug(&self, msg: &str) {
+        T::write_debug(self, msg);
+    }
+}
+
 mod erased_runtime {
     use super::*;
 

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 bincode.workspace = true
 boa_engine.workspace = true
+hex.workspace = true
 http-serde.workspace = true
 http.workspace = true
 jstz_api = { path = "../jstz_api" }


### PR DESCRIPTION
# Context
Part of 574
[task link](https://linear.app/tezos/issue/JSTZ-605/decouple-the-kernel-parse-logic-from-the-runtime)

the indexer or the sequencer has to parse the L1 inbox messages and this PR exposes functionality to parse l1 inbox messages without having to use the runtime.
# Description

* Introduce a new trait `WriteDebug` to decouple the write_debug functionailty from the host runtime
* Separated the parsing logic from the `read_message` in the kernel
* make the parser's helper functions take `WriteDebug` instead of the Runtime
* the logic for parsing remains the same

For example, given the following L1 inbox messages:
```
"messages": [
    "0001",
    "0003000000006835e47f5e45deeed35c489b723db055a2c2a40f50a1fe5932583a4a3b2d358fa8e8082c",
    "0002"
  ],
```
To decode the second message we can use the parse function where the inbox id corresponds to the index of the messages:
```
parse_inbox_message_hex(logger, 1, messages[1], TICKETER, ROLLUP_ADDRESS)
```


# Manually testing the PR

cargo run -p jstz_kernel
