### PR TITLE
fix(cli): launch sandbox container with init

### DIFF
--- a/crates/jstz_cli/src/sandbox/container.rs
+++ b/crates/jstz_cli/src/sandbox/container.rs
@@ -238,6 +238,7 @@ fn new_create_container_config(
             port_bindings: create_port_bindings(ports.as_ref()),
             auto_remove: Some(true),
             network_mode: Some("bridge".to_string()),
+            init: Some(true),
             ..Default::default()
         }),
         attach_stdin: Some(true),
@@ -440,6 +441,7 @@ mod tests {
                     )])),
                     network_mode: Some("bridge".to_owned()),
                     auto_remove: Some(true),
+                    init: Some(true),
                     ..Default::default()
                 }),
                 attach_stdin: Some(true),


### PR DESCRIPTION
# Context

Completes JSTZ-618.
Closes #1038.

# Description

Launch sandbox container with `init`, equivalent to `docker run --init`.

This makes sure that PID 1 in the container is going to be a lightweight init process that collects zombies. Based on my observation, this is probably due to something going on in the rollup node. `ps` in the container sometimes showed the following:

```
$ ps                                                                                                                                                                
PID   USER     TIME  COMMAND                                                                                                                                          
    1 root      0:43 /usr/bin/jstzd run /code/config.json                          
   24 root      0:05 octez-node run --data-dir /tmp/.tmp7Ytovb --singleprocess --s 
   44 root      0:02 octez-baker-PsRiotum --base-dir /tmp/.tmpTNbfbo --endpoint ht 
   59 root      0:49 octez-smart-rollup-node --endpoint http://localhost:44861 --b 
   91 root      0:00 /bin/sh                                                       
  134 root      0:00 [uname]                                                       
  136 root      0:00 [uname]                                                       
  138 root      0:00 [uname]                                                       
  141 root      0:00 octez-smart-rollup-node --endpoint http://localhost:44861 --b                                                                                    
  142 root      0:00 [uname]                                                                                                                                          
  143 root      0:00 ps
```
and shortly afterwards
```
$ ps                                                                             
PID   USER     TIME  COMMAND                                                       
    1 root      0:44 /usr/bin/jstzd run /code/config.json                          
   24 root      0:05 octez-node run --data-dir /tmp/.tmp7Ytovb --singleprocess --s 
   44 root      0:02 octez-baker-PsRiotum --base-dir /tmp/.tmpTNbfbo --endpoint ht 
   59 root      0:50 octez-smart-rollup-node --endpoint http://localhost:44861 --b                                                                                    
   91 root      0:00 /bin/sh                                                                                                                                          
  134 root      0:00 [uname]                                                                                                                                          
  136 root      0:00 [uname]                                                       
  138 root      0:00 [uname]                                                                                                                                          
  142 root      0:00 [uname]                                                       
  144 root      0:00 ps          
```

where the second rollup node process (141) disappeared while `uname` (142) remained. And it just continued like this with more and more `uname` processes lingering.

I didn't really dive into their source code, but it seems that they periodically check the platform name with `uname` for something. Somehow the rollup node process does not wait for this uname child and therefore it becomes PID 1's duty to collect it, but in our case PID 1 is jstzd and it simply doesn't do this. Adding this `--init` flag makes sure that PID 1 will be init in the container and that these zombies get picked up. 

# Manually testing the PR

Built CLI locally and launched the sandbox. Didn't see the dangling processes afterwards.
