### PR TITLE
refactor(sequencer): implement store wrapper

### DIFF
--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -9,7 +9,7 @@ use crate::services::accounts::get_account_nonce;
 use crate::RunMode;
 
 use super::error::{ServiceError, ServiceResult};
-use super::utils;
+use super::utils::StoreWrapper;
 use super::{AppState, Service};
 use anyhow::anyhow;
 use anyhow::Context;
@@ -224,8 +224,8 @@ async fn receipt(
 ) -> ServiceResult<Json<Receipt>> {
     let key = format!("/jstz_receipt/{}", hash);
 
-    let value =
-        utils::read_value_from_store(mode, rollup_client, runtime_db, key).await?;
+    let store = StoreWrapper::new(mode, rollup_client, runtime_db);
+    let value = store.get_value(key).await?;
 
     let receipt = match value {
         Some(value) => Receipt::decode(value.as_slice())


### PR DESCRIPTION
# Context

Part of JSTZ-592.
[JSTZ-592](https://linear.app/tezos/issue/JSTZ-592/deal-with-large-payload)

# Description

Implemented `StoreWrapper` that abstracts how values are read from different sources, i.e. the rollup node or the local runtime database. This makes it easier to access the data sources without having to pass in both rollup client and db connection pool each time. For instance,

```rs
async fn get_account_nonce_from_store(
    mode: RunMode,
    rollup_client: OctezRollupClient,
    runtime_db: Db,
    address: &str,
) -> ServiceResult<Option<Nonce>> {
    match mode { ... }
}
```

is simplified to
```rs
async fn get_account_nonce_from_store(
    store: StoreWrapper,
    address: &str,
) -> ServiceResult<Option<Nonce>> {
    store.get_value(...)
}
```

# Manually testing the PR

* Unit testing: added tests and updated existing ones
