### PR TITLE
feat(sequencer): add global block api

### DIFF
--- a/crates/jstz_node/src/sequencer/inbox/api.rs
+++ b/crates/jstz_node/src/sequencer/inbox/api.rs
@@ -1,0 +1,102 @@
+#![allow(dead_code)]
+use anyhow::Result;
+use futures_util::{Stream, StreamExt, TryStreamExt};
+use serde::Deserialize;
+#[cfg(test)]
+use serde::Serialize;
+use std::io;
+use std::time::Duration;
+use tokio_util::codec::{FramedRead, LinesCodec};
+use tokio_util::io::StreamReader;
+
+/// Response structure for block data containing inbox messages.
+/// Each message in the inbox is represented as a hex-encoded string.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
+pub struct BlockResponse {
+    pub messages: Vec<String>,
+}
+
+/// Fetches block data from the rollup node for a specific block level.
+pub async fn fetch_block(
+    rollup_endpoint: &str,
+    block_level: u32,
+) -> Result<BlockResponse> {
+    let url = format!("{}/global/block/{}", rollup_endpoint, block_level);
+    let response = reqwest::get(url).await?;
+    let block: BlockResponse = response.json().await?;
+    Ok(block)
+}
+
+/// Response structure for block monitoring, containing the block level information.
+#[derive(Debug, Deserialize)]
+pub struct MonitorBlocksResponse {
+    pub level: u32,
+}
+
+/// Establishes a streaming connection to monitor new blocks from the rollup node.
+/// This function creates a long-lived connection that will receive updates whenever
+/// new blocks are produced by the rollup node.
+///
+/// # Note
+/// The connection uses TCP keepalive to maintain the connection and will automatically
+/// attempt to reconnect if the connection is lost.
+pub async fn monitor_blocks(
+    rollup_endpoint: &str,
+) -> Result<impl Stream<Item = Result<MonitorBlocksResponse, anyhow::Error>> + Unpin> {
+    let url = format!("{}/global/monitor_blocks", rollup_endpoint);
+    let client = reqwest::Client::builder()
+        .tcp_keepalive(Some(Duration::from_secs(10)))
+        .build()?;
+    let response = client.get(url).send().await?;
+    let bytes_stream = response.bytes_stream();
+    let reader = StreamReader::new(
+        bytes_stream.map_err(|e| io::Error::new(io::ErrorKind::Other, e)),
+    );
+    let line_stream = FramedRead::new(reader, LinesCodec::new());
+    let response_stream = line_stream.map(|result| match result {
+        Ok(line) => Ok(serde_json::from_str::<MonitorBlocksResponse>(&line).unwrap()),
+        Err(e) => Err(e.into()),
+    });
+    Ok(response_stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sequencer::inbox::{
+        api::{fetch_block, monitor_blocks},
+        test_utils::{make_mock_global_block_filter, make_mock_monitor_blocks_filter},
+    };
+    use tokio::task;
+    use tokio_stream::StreamExt;
+
+    #[tokio::test]
+    async fn test_monitor_blocks() {
+        let (addr, server) = warp::serve(make_mock_monitor_blocks_filter())
+            .bind_ephemeral(([127, 0, 0, 1], 0));
+        task::spawn(server);
+        let endpoint = format!("http://{}", addr);
+
+        let mut stream = monitor_blocks(&endpoint).await.unwrap();
+
+        // Read and parse first block
+        let block = stream.next().await.unwrap().unwrap();
+        assert_eq!(block.level, 123);
+
+        // Read and parse second block
+        let block = stream.next().await.unwrap().unwrap();
+        assert_eq!(block.level, 124);
+    }
+
+    #[tokio::test]
+    async fn test_global_block() {
+        let (addr, server) = warp::serve(make_mock_global_block_filter())
+            .bind_ephemeral(([127, 0, 0, 1], 0));
+        task::spawn(server);
+        let endpoint = format!("http://{}", addr);
+
+        // Test block endpoint
+        let block_response = fetch_block(&endpoint, 123).await.unwrap();
+        assert_eq!(block_response.messages, vec!["message for block 123"]);
+    }
+}

--- a/crates/jstz_node/src/sequencer/inbox/mod.rs
+++ b/crates/jstz_node/src/sequencer/inbox/mod.rs
@@ -1,26 +1,19 @@
-use std::{
-    io,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::sync::{Arc, RwLock};
+
+#[cfg(not(test))]
+use std::time::Duration;
 
 use crate::sequencer::queue::OperationQueue;
 use anyhow::Result;
 use async_dropper_simple::AsyncDrop;
 use async_trait::async_trait;
-use bytes::Bytes;
-use futures_util::{Stream, TryStreamExt};
-use serde::Deserialize;
 #[cfg(test)]
 use std::future::Future;
 use tokio::{select, task::JoinHandle};
 use tokio_stream::StreamExt;
-use tokio_util::{
-    codec::{FramedRead, LinesCodec},
-    io::StreamReader,
-    sync::CancellationToken,
-};
+use tokio_util::sync::CancellationToken;
 
+mod api;
 mod parsing;
 
 #[derive(Default)]
@@ -45,11 +38,6 @@ impl AsyncDrop for Monitor {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct MonitorBlocksResponse {
-    level: u32,
-}
-
 /// Spawn a future that monitors the L1 blocks, parses inbox messages and pushes them into the queue.
 pub async fn spawn_monitor<
     #[cfg(test)] Fut: Future<Output = ()> + 'static + Send,
@@ -65,22 +53,16 @@ pub async fn spawn_monitor<
     tokio::time::sleep(Duration::from_secs(3)).await;
     let kill_sig = CancellationToken::new();
     let kill_sig_clone = kill_sig.clone();
-
-    let bytes_stream = monitor_blocks(&rollup_endpoint).await?;
-    let reader = StreamReader::new(
-        bytes_stream.map_err(|e| io::Error::new(io::ErrorKind::Other, e)),
-    );
-    let mut line_stream = FramedRead::new(reader, LinesCodec::new());
+    let mut block_stream = api::monitor_blocks(&rollup_endpoint).await?;
     let handle = tokio::spawn(async move {
         loop {
             select! {
                 _ = kill_sig_clone.cancelled() => {
                     break;
                 }
-                result = line_stream.next() => {
+                result = block_stream.next() => {
                     match result {
-                        Some(Ok(line)) => {
-                            let block = serde_json::from_str::<MonitorBlocksResponse>(&line).unwrap();
+                        Some(Ok(block)) => {
                             //TODO: fetch inbox messages and place into the queue
                             println!("block level: {}\n", block.level);
                             #[cfg(test)]
@@ -104,66 +86,18 @@ pub async fn spawn_monitor<
     })
 }
 
-/// Establishes a streaming connection to monitor new blocks from the rollup node.
-/// Returns a stream of bytes that can be parsed into block information.
-pub async fn monitor_blocks(
-    rollup_endpoint: &str,
-) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>> + Unpin> {
-    let url = format!("{}/global/monitor_blocks", rollup_endpoint);
-    let client = reqwest::Client::builder()
-        .tcp_keepalive(Some(Duration::from_secs(10)))
-        .build()?;
-    let response = client.get(url).send().await?;
-    Ok(response.bytes_stream())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::stream;
-    use std::{convert::Infallible, time::Duration};
+    use crate::sequencer::inbox::test_utils::make_mock_monitor_blocks_filter;
+    use std::time::Duration;
     use std::{
         future::Future,
         pin::Pin,
         sync::{Arc, Mutex, RwLock},
     };
-    use tokio::{task, time::sleep};
-    use warp::{hyper::Body, Filter};
-
-    struct MockServer(JoinHandle<()>);
-    impl Drop for MockServer {
-        fn drop(&mut self) {
-            self.0.abort();
-        }
-    }
-
-    /// mock the /global/monitor_blocks endpoint
-    fn make_mock_monitor_blocks(
-    ) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
-    {
-        warp::path!("global" / "monitor_blocks").map(|| {
-            let delay_stream = stream::once(async {
-                sleep(Duration::from_millis(300)).await;
-                Ok::<Bytes, Infallible>(Bytes::new())
-            });
-
-            let data_stream = stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(
-                "{\"level\": 123}\n",
-            ))])
-            .chain(delay_stream)
-            .chain(stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(
-                "{\"level\": 124}\n",
-            ))]));
-            warp::reply::Response::new(Body::wrap_stream(data_stream))
-        })
-    }
-
-    fn make_mock_server() -> (String, MockServer) {
-        let filter = make_mock_monitor_blocks();
-        let (addr, server) = warp::serve(filter).bind_ephemeral(([127, 0, 0, 1], 0));
-        let url = format!("http://{}", addr);
-        (url, MockServer(task::spawn(server)))
-    }
+    use tokio::task;
+    use tokio::time::sleep;
 
     fn make_on_new_block() -> (
         Arc<Mutex<u32>>,
@@ -183,27 +117,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_monitor_blocks() {
-        let (endpoint, _server) = make_mock_server();
-
-        let mut stream = monitor_blocks(&endpoint).await.unwrap();
-
-        // Read and parse first block
-        let bytes = stream.next().await.unwrap().unwrap();
-        let line = String::from_utf8(bytes.to_vec()).unwrap();
-        let block: MonitorBlocksResponse = serde_json::from_str(&line).unwrap();
-        assert_eq!(block.level, 123);
-
-        // Read and parse second block
-        let bytes = stream.next().await.unwrap().unwrap();
-        let line = String::from_utf8(bytes.to_vec()).unwrap();
-        let block: MonitorBlocksResponse = serde_json::from_str(&line).unwrap();
-        assert_eq!(block.level, 124);
-    }
-
-    #[tokio::test]
     async fn test_spawn_shuts_down() {
-        let (endpoint, _server) = make_mock_server();
+        let (addr, server) = warp::serve(make_mock_monitor_blocks_filter())
+            .bind_ephemeral(([127, 0, 0, 1], 0));
+        task::spawn(server);
+        let endpoint = format!("http://{}", addr);
         let q = Arc::new(RwLock::new(OperationQueue::new(0)));
         let (counter, on_new_block) = make_on_new_block();
         let mut monitor = spawn_monitor(endpoint.clone(), q.clone(), on_new_block)
@@ -218,7 +136,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn() {
-        let (endpoint, _server) = make_mock_server();
+        let (addr, server) = warp::serve(make_mock_monitor_blocks_filter())
+            .bind_ephemeral(([127, 0, 0, 1], 0));
+        task::spawn(server);
+        let endpoint = format!("http://{}", addr);
         let q = Arc::new(RwLock::new(OperationQueue::new(0)));
         let (counter, on_new_block) = make_on_new_block();
         let _ = spawn_monitor(endpoint, q, on_new_block).await.unwrap();
@@ -226,5 +147,48 @@ mod tests {
         assert_eq!(*counter.lock().unwrap(), 123);
         sleep(Duration::from_millis(400)).await;
         assert_eq!(*counter.lock().unwrap(), 124);
+    }
+}
+
+#[cfg(test)]
+mod test_utils {
+    use super::{api::BlockResponse, *};
+    use bytes::Bytes;
+    use futures_util::stream;
+    use std::{convert::Infallible, time::Duration};
+    use tokio::time::sleep;
+    use warp::{hyper::Body, Filter};
+
+    /// mock the /global/monitor_blocks endpoint
+    pub(crate) fn make_mock_monitor_blocks_filter(
+    ) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
+    {
+        warp::path!("global" / "monitor_blocks").map(|| {
+            let delay_stream = stream::once(async {
+                sleep(Duration::from_millis(300)).await;
+                Ok::<Bytes, Infallible>(Bytes::new())
+            });
+
+            let data_stream = stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(
+                "{\"level\": 123}\n",
+            ))])
+            .chain(delay_stream)
+            .chain(stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(
+                "{\"level\": 124}\n",
+            ))]));
+            warp::reply::Response::new(Body::wrap_stream(data_stream))
+        })
+    }
+
+    /// mock the /global/block/[block_level] endpoint
+    pub(crate) fn make_mock_global_block_filter(
+    ) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
+    {
+        warp::path!("global" / "block" / u32).map(|level: u32| {
+            let response = BlockResponse {
+                messages: vec![format!("message for block {}", level)],
+            };
+            warp::reply::json(&response)
+        })
     }
 }


### PR DESCRIPTION
# Context
Part of 574
[task link](https://linear.app/tezos/issue/JSTZ-633/add-globalblocklevel-api)

# Description

* moved the `monitor_blocks` api from `inbox/mod.rs` -> `inbox/api.rs` 
* refactored monitor_blocks to return a stream of `MonitorBlockResponse` instead of bytes stream.
* refactored the mock server creation logic and exported from mod test_utils to make them reusable
* added new api to fetch the inbox messages. `/global/block/[level]`


# Manually testing the PR

cargo test -p jstz_node
