### PR TITLE
fix(ci): completely remove old dev doc files

### DIFF
--- a/.github/workflows/deploy-dev-docs.yml
+++ b/.github/workflows/deploy-dev-docs.yml
@@ -62,7 +62,7 @@ jobs:
           path: dest_repo
       - name: push to destination repo
         run: |
-          cd $GITHUB_WORKSPACE/dest_repo/ && find . -mindepth 1 -maxdepth 1 ! -name '.git' -type d -exec rm -rf {} +
+          cd $GITHUB_WORKSPACE/dest_repo/ && find . -mindepth 1 -maxdepth 1 ! -name '.git' -type d -exec rm -rf {} + && find . -mindepth 1 -maxdepth 1 ! -name '.git' -type f -exec rm {} +
           mv $GITHUB_WORKSPACE/docs/* $GITHUB_WORKSPACE/dest_repo/
           if [[ ! `git status --porcelain` ]]; then
             echo "No change in docs"


### PR DESCRIPTION
# Context

Some pages in dev docs, e.g. [/quick_start.html](https://github.com/jstz-dev/dev-docs/blob/eaa1c69aaffda62e2fc2a0d493bc67453c6330b7/quick_start.html), do not render properly but complain that some asset files are missing. It turns out that those are old files not cleaned up.

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/488a8ca6-f552-44d2-8d8c-9fc3fcbe4844" />


# Description

Updated the workflow such that everything except the git files in the target directory are cleaned up before the newly built dev docs are pushed to the target directory.

# Manually testing the PR

Tested the updated script locally and confirmed that all relevant files were removed.
