### PR TITLE
feat(jstzd): run sequencer

### DIFF
--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -53,6 +53,8 @@ tezos_crypto_rs.workspace = true
 [features]
 skip-rollup-tests = []
 build-image = ["octez/disable-alpha"]
+v2_runtime = ["jstz_node/v2_runtime"]
+sequencer = []
 
 [[bin]]
 name = "jstzd"

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -168,7 +168,13 @@ pub async fn build_config(mut config: Config) -> Result<(u16, JstzdConfig)> {
         &jstz_rollup_path::preimages_path(),
         &kernel_debug_file_path,
         KeyPair::default(),
+        #[cfg(feature = "sequencer")]
+        jstz_node::RunMode::Sequencer,
+        #[cfg(not(feature = "sequencer"))]
         jstz_node::RunMode::Default,
+        #[cfg(feature = "sequencer")]
+        1024,
+        #[cfg(not(feature = "sequencer"))]
         0,
     );
 


### PR DESCRIPTION
# Context

Completes JSTZ-552.
[JSTZ-552](https://linear.app/tezos/issue/JSTZ-552/run-sequencer-in-sandbox)

# Description

Updated jstzd config such that jstzd spins up jstz node in sequencer mode when the feature flag `sequencer` is set. One additional feature flag `v2_runtime` is introduced to use v2 runtime in jstz node.

# Manually testing the PR

Built and ran jstzd locally with the feature flag and observed that sequencer was indeed running.
