### PR TITLE
feat(sequencer): dump logs to debug file

### DIFF
--- a/crates/jstz_node/src/sequencer/mod.rs
+++ b/crates/jstz_node/src/sequencer/mod.rs
@@ -7,11 +7,11 @@ pub mod worker;
 
 #[cfg(test)]
 pub mod tests {
-    use axum::http::{HeaderMap, Method, Uri};
     use jstz_crypto::{public_key::PublicKey, signature::Signature};
     use jstz_proto::{
         context::account::Nonce,
-        operation::{Content, Operation, RunFunction, SignedOperation},
+        operation::{Content, DeployFunction, Operation, SignedOperation},
+        runtime::ParsedCode,
     };
     use tezos_crypto_rs::hash::{Ed25519Signature, PublicKeyEd25519};
 
@@ -19,22 +19,19 @@ pub mod tests {
 
     pub fn dummy_op() -> Message {
         let inner = SignedOperation::new(
-        Signature::Ed25519(Ed25519Signature::from_base58_check("edsigtbD6jADoivxf1iho6mDYPGiVvXw4Hnurn6VzDLG1boyMmmHEAykSrUJjJpvEsHHjQNvLWfm9PdyMBfJ8CX7jSEkh3yrB6m").unwrap().into()),
+        Signature::Ed25519(Ed25519Signature::from_base58_check("edsigtkikkYx71PqeJigBom8sAf8ajRqynraWUFxej5XcbVFSzga6gHYz7whJTFJhZZRywQfXKUjSQeXHPikHJt114hUTEXJzED").unwrap().into()),
          Operation {
             public_key: PublicKey::Ed25519(
                 PublicKeyEd25519::from_base58_check(
-                    "edpkuUXUFt2E51TkMjRarDEVWXGB4kLKoTryMDyMhNyxFCRTsPDd1K",
+                    "edpkuXD2CqRpWoTT8p4exrMPQYR2NqsYH3jTMeJMijHdgQqkMkzvnz",
                 )
                 .unwrap()
                 .into(),
             ),
             nonce: Nonce(0),
-            content: Content::RunFunction(RunFunction {
-                uri: Uri::from_static("http://http://"),
-                method: Method::HEAD,
-                headers: HeaderMap::new(),
-                body: None,
-                gas_limit: 0,
+            content: Content::DeployFunction(DeployFunction {
+                account_credit: 0,
+                function_code: ParsedCode("1\n".to_string())
             }),
         },
     );


### PR DESCRIPTION
# Context

Completes JSTZ-644.
[JSTZ-644](https://linear.app/tezos/issue/JSTZ-644/add-debug-log-file)

The sequencer needs a place to collect all logs. Currently they are written to stdout.

# Description

Updated host such that it writes debug logs to a debug log file when the path to the file is provided. It calls `log::debug` otherwise.

# Manually testing the PR

* Unit testing: added unit tests
