### PR TITLE
feat(proto): log requests with host

### DIFF
--- a/crates/jstz_proto/src/lib.rs
+++ b/crates/jstz_proto/src/lib.rs
@@ -8,3 +8,33 @@ pub mod request_logger;
 pub use error::{Error, Result};
 
 pub mod runtime;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tezos_smart_rollup_mock::DebugSink;
+
+    pub struct DebugLogSink {
+        pub inner: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl DebugSink for DebugLogSink {
+        fn write_all(&mut self, buffer: &[u8]) -> std::io::Result<()> {
+            self.inner.lock().unwrap().extend_from_slice(buffer);
+            Ok(())
+        }
+    }
+
+    impl DebugLogSink {
+        pub fn new() -> Self {
+            Self {
+                inner: Arc::new(Mutex::new(vec![])),
+            }
+        }
+
+        pub fn content(&self) -> Arc<Mutex<Vec<u8>>> {
+            self.inner.clone()
+        }
+    }
+}

--- a/crates/jstz_proto/src/request_logger.rs
+++ b/crates/jstz_proto/src/request_logger.rs
@@ -1,6 +1,9 @@
 use std::fmt::{self, Display};
 
-use jstz_core::{host::HostRuntime, runtime};
+use jstz_core::{
+    host::{HostRuntime, JsHostRuntime},
+    runtime,
+};
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use serde::{Deserialize, Serialize};
 
@@ -36,25 +39,124 @@ impl RequestEvent {
 }
 
 pub fn log_request_start(address: SmartFunctionHash, request_id: String) {
+    runtime::with_js_hrt(|hrt| {
+        log_request_start_with_host(hrt, address, request_id);
+    });
+}
+
+pub fn log_request_start_with_host(
+    hrt: &mut JsHostRuntime<'static>,
+    address: SmartFunctionHash,
+    request_id: String,
+) {
     let request_log = RequestEvent::Start {
         address,
         request_id,
     }
     .to_string();
 
-    runtime::with_js_hrt(|hrt| {
-        hrt.write_debug(&(REQUEST_START_PREFIX.to_string() + &request_log + "\n"));
-    });
+    hrt.write_debug(&(REQUEST_START_PREFIX.to_string() + &request_log + "\n"));
 }
 
 pub fn log_request_end(address: SmartFunctionHash, request_id: String) {
+    runtime::with_js_hrt(|hrt| {
+        log_request_end_with_host(hrt, address, request_id);
+    });
+}
+
+pub fn log_request_end_with_host(
+    hrt: &mut JsHostRuntime<'static>,
+    address: SmartFunctionHash,
+    request_id: String,
+) {
     let request_log = RequestEvent::End {
         address,
         request_id,
     }
     .to_string();
 
-    runtime::with_js_hrt(|hrt| {
-        hrt.write_debug(&(REQUEST_END_PREFIX.to_string() + &request_log + "\n"));
-    });
+    hrt.write_debug(&(REQUEST_END_PREFIX.to_string() + &request_log + "\n"));
+}
+
+#[cfg(test)]
+mod tests {
+    use jstz_core::{host::JsHostRuntime, kv::Transaction};
+    use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
+    use tezos_smart_rollup_mock::MockHost;
+
+    use crate::tests::DebugLogSink;
+
+    #[test]
+    fn log_request_start() {
+        let sink = DebugLogSink::new();
+        let buf = sink.content();
+        let mut host = MockHost::default();
+        host.set_debug_handler(sink);
+        jstz_core::runtime::enter_js_host_context(
+            &mut JsHostRuntime::new(&mut host),
+            &mut Transaction::default(),
+            || {
+                super::log_request_start(
+                    SmartFunctionHash::from_base58(
+                        "KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9",
+                    )
+                    .unwrap(),
+                    "start_request".to_string(),
+                )
+            },
+        );
+        assert_eq!(String::from_utf8(buf.lock().unwrap().to_vec()).unwrap(), "[JSTZ:SMART_FUNCTION:REQUEST_START] {\"type\":\"Start\",\"address\":\"KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9\",\"request_id\":\"start_request\"}\n");
+    }
+
+    #[test]
+    fn log_request_start_with_host() {
+        let sink = DebugLogSink::new();
+        let buf = sink.content();
+        let mut host = MockHost::default();
+        host.set_debug_handler(sink);
+        super::log_request_start_with_host(
+            &mut JsHostRuntime::new(&mut host),
+            SmartFunctionHash::from_base58("KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9")
+                .unwrap(),
+            "foobar".to_string(),
+        );
+        assert_eq!(String::from_utf8(buf.lock().unwrap().to_vec()).unwrap(), "[JSTZ:SMART_FUNCTION:REQUEST_START] {\"type\":\"Start\",\"address\":\"KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9\",\"request_id\":\"foobar\"}\n");
+    }
+
+    #[test]
+    fn log_request_end() {
+        let sink = DebugLogSink::new();
+        let buf = sink.content();
+        let mut host = MockHost::default();
+        host.set_debug_handler(sink);
+        jstz_core::runtime::enter_js_host_context(
+            &mut JsHostRuntime::new(&mut host),
+            &mut Transaction::default(),
+            || {
+                super::log_request_end(
+                    SmartFunctionHash::from_base58(
+                        "KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9",
+                    )
+                    .unwrap(),
+                    "end_request".to_string(),
+                )
+            },
+        );
+        assert_eq!(String::from_utf8(buf.lock().unwrap().to_vec()).unwrap(), "[JSTZ:SMART_FUNCTION:REQUEST_END] {\"type\":\"End\",\"address\":\"KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9\",\"request_id\":\"end_request\"}\n");
+    }
+
+    #[test]
+    fn log_request_end_with_host() {
+        let sink = DebugLogSink::new();
+        let buf = sink.content();
+        let mut host = MockHost::default();
+        host.set_debug_handler(sink);
+        super::log_request_end_with_host(
+            &mut JsHostRuntime::new(&mut host),
+            SmartFunctionHash::from_base58("KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9")
+                .unwrap(),
+            "foobar".to_string(),
+        );
+        assert_eq!(String::from_utf8(buf.lock().unwrap().to_vec()).unwrap(), "[JSTZ:SMART_FUNCTION:REQUEST_END] {\"type\":\"End\",\"address\":\"KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9\",\"request_id\":\"foobar\"}\n");
+    }
 }


### PR DESCRIPTION
# Context

Part of JSTZ-647.
[JSTZ-647](https://linear.app/tezos/issue/JSTZ-647/log-operation-details-for-v2-runtime)

V2 runtime has no logging basically.

# Description

Added helper functions that make the specified host runtime write debug logs. These new functions are basically the same as the old ones, `log_request_start` and `log_request_end`.

# Manually testing the PR

* Unit testing: added tests
