### PR TITLE
fix(sequencer): use tokio RwLock

### DIFF
--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -14,12 +14,9 @@ use services::{
     operations::OperationsService,
     utils,
 };
-use std::{
-    path::PathBuf,
-    sync::{Arc, RwLock},
-};
+use std::{path::PathBuf, sync::Arc};
 use tempfile::NamedTempFile;
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, sync::RwLock};
 use tower_http::cors::{Any, CorsLayer};
 
 mod api_doc;

--- a/crates/jstz_node/src/services/utils.rs
+++ b/crates/jstz_node/src/services/utils.rs
@@ -44,10 +44,8 @@ impl StoreWrapper {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::{
-        path::PathBuf,
-        sync::{Arc, RwLock},
-    };
+    use std::{path::PathBuf, sync::Arc};
+    use tokio::sync::RwLock;
 
     use jstz_core::BinEncodable;
     use jstz_crypto::{


### PR DESCRIPTION
# Context

Closes [task link](https://linear.app/tezos/issue/JSTZ-636/make-worker-spawn-async-aware)

The sequencer currently uses a blocking lock inside tokio runtime. Blocking inside a tokio task can block the entire Tokio core thread which could lead to a performance issue when the number of access to the queue increases. This PR fixes it.
# Description

* Replaced the `std::sync::RwLock` with a non blocking lock `tokio::sync::RwLock`


# Manually testing the PR

existing test works
