### PR TITLE
feat(proto): log request start and end with v2 runtime

### DIFF
--- a/crates/jstz_proto/src/runtime/v2/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/mod.rs
@@ -19,9 +19,9 @@ pub async fn run_toplevel_fetch(
     tx: &mut Transaction,
     source_address: &(impl Addressable + 'static),
     run_operation: RunFunction,
-    _operation_hash: OperationHash,
+    operation_hash: OperationHash,
 ) -> Result<RunFunctionReceipt, crate::Error> {
-    Ok(run(hrt, tx, source_address, run_operation, _operation_hash).await?)
+    Ok(run(hrt, tx, source_address, run_operation, operation_hash).await?)
 }
 
 async fn run(
@@ -29,7 +29,7 @@ async fn run(
     tx: &mut Transaction,
     source_address: &(impl Addressable + 'static),
     run_operation: RunFunction,
-    _operation_hash: OperationHash,
+    operation_hash: OperationHash,
 ) -> Result<RunFunctionReceipt, Error> {
     let url =
         Url::parse(run_operation.uri.to_string().as_str()).map_err(FetchError::from)?;
@@ -37,6 +37,7 @@ async fn run(
     let response: http::Response<Option<Vec<u8>>> = process_and_dispatch_request(
         JsHostRuntime::new(hrt),
         tx.clone(),
+        Some(operation_hash),
         source_address.clone().into(),
         run_operation.method.to_string().into(),
         url,


### PR DESCRIPTION
# Context

Part of JSTZ-647.
[JSTZ-647](https://linear.app/tezos/issue/JSTZ-647/log-operation-details-for-v2-runtime)

V2 runtime has no logging basically.

# Description

Updated the v2 request handler such that log lines are printed before and after an execution. A sample line looks as follows:
```
[JSTZ:SMART_FUNCTION:REQUEST_START] {"type":"Start","address":"KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9","request_id":"afc02a7556649a25c0583e9168e5e862bbefa19b79c41c34b3c0bca38b15a0f5"}
[JSTZ:SMART_FUNCTION:REQUEST_END] {"type":"End","address":"KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9","request_id":"afc02a7556649a25c0583e9168e5e862bbefa19b79c41c34b3c0bca38b15a0f5"}
```

This is the same as what is implemented for v1 runtime.

# Manually testing the PR

* Unit testing: added a test
