### PR TITLE
feat(proto): log response status

### DIFF
--- a/crates/jstz_node/src/services/logs/db.rs
+++ b/crates/jstz_node/src/services/logs/db.rs
@@ -5,9 +5,7 @@ use super::Line;
 use anyhow::{anyhow, Result};
 use jstz_api::js_log::LogLevel;
 use jstz_crypto::public_key_hash::PublicKeyHash;
-use jstz_proto::{
-    context::account::Address, js_logger::LogRecord, request_logger::RequestEvent,
-};
+use jstz_proto::{context::account::Address, js_logger::LogRecord, logger::RequestEvent};
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{params, Params, Statement};

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -9,9 +9,7 @@ use axum::{
 use broadcaster::InfallibleSSeStream;
 use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
 #[cfg(feature = "persistent-logging")]
-use jstz_proto::request_logger::{
-    RequestEvent, REQUEST_END_PREFIX, REQUEST_START_PREFIX,
-};
+use jstz_proto::logger::{RequestEvent, REQUEST_END_PREFIX, REQUEST_START_PREFIX};
 use jstz_proto::runtime::{LogRecord, LOG_PREFIX};
 use jstz_utils::tailed_file::TailedFile;
 use serde::Deserialize;

--- a/crates/jstz_proto/src/lib.rs
+++ b/crates/jstz_proto/src/lib.rs
@@ -4,9 +4,9 @@ pub mod context;
 #[cfg(feature = "v2_runtime")]
 pub mod event;
 pub mod executor;
+pub mod logger;
 pub mod operation;
 pub mod receipt;
-pub mod request_logger;
 pub mod storage;
 pub use error::{Error, Result};
 

--- a/crates/jstz_proto/src/runtime/v1/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v1/fetch_handler.rs
@@ -15,9 +15,9 @@ use crate::{
     context::account::{Account, Address, Addressable},
     error::{self, Result},
     executor::smart_function::{JSTZ_HOST, NOOP_PATH},
+    logger::{log_request_end, log_request_start},
     operation::{OperationHash, RunFunction},
     receipt::RunFunctionReceipt,
-    request_logger::{log_request_end, log_request_start},
     Error,
 };
 

--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -1,5 +1,5 @@
+use crate::logger::{log_request_end_with_host, log_request_start_with_host};
 use crate::operation::OperationHash;
-use crate::request_logger::{log_request_end_with_host, log_request_start_with_host};
 use crate::runtime::v2::fetch::error::{FetchError, Result};
 use crate::runtime::v2::ledger;
 


### PR DESCRIPTION
# Context

Part of JSTZ-670.
[JSTZ-670](https://linear.app/tezos/issue/JSTZ-670/log-receipt-statuses)

# Description

Implemented a new helper function for logging `log_response_status_code` that records response statuses. Status code will be exposed through debug logs and captured by logging agents in the environment.

The following things are logged:
* request URL: this covers things other than validated function calls so that we can monitor rubbish requests as well.
* request ID: operation hashes that will allow us to trace back to requests.
* status code: the main thing that will be exposed as metrics.

Also renamed module `request_logger` to `logger` since this module now also covers response logging.

# Manually testing the PR

* Unit testing: added tests.
