### PR TITLE
fix(jstzd): make docker build features configurable

### DIFF
--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -28,7 +28,6 @@ use tokio::io::AsyncReadExt;
 
 const DEFAULT_JSTZD_SERVER_PORT: u16 = 54321;
 const DEFAULT_JSTZ_NODE_ENDPOINT: &str = "0.0.0.0:8933";
-const DEFAULT_OCTEZ_ROLLUP_ENDPOINT: &str = "0.0.0.0:18751";
 pub const BOOTSTRAP_CONTRACT_NAMES: [(&str, &str); 2] = [
     ("exchanger", EXCHANGER_ADDRESS),
     ("jstz_native_bridge", JSTZ_NATIVE_BRIDGE_ADDRESS),
@@ -152,11 +151,6 @@ pub async fn build_config(mut config: Config) -> Result<(u16, JstzdConfig)> {
     if !rollup_builder.has_boot_sector_file() {
         rollup_builder = rollup_builder
             .set_boot_sector_file(jstz_rollup_path::kernel_installer_path());
-    }
-    if !rollup_builder.has_rpc_endpoint() {
-        rollup_builder = rollup_builder.set_rpc_endpoint(
-            &Endpoint::try_from(Uri::from_static(DEFAULT_OCTEZ_ROLLUP_ENDPOINT)).unwrap(),
-        );
     }
 
     let octez_rollup_config = rollup_builder

--- a/crates/octez/src/async/rollup.rs
+++ b/crates/octez/src/async/rollup.rs
@@ -188,10 +188,6 @@ impl OctezRollupConfigBuilder {
         self.boot_sector_file.is_some()
     }
 
-    pub fn has_rpc_endpoint(&self) -> bool {
-        self.rpc_endpoint.is_some()
-    }
-
     pub fn build(self) -> Result<OctezRollupConfig> {
         Ok(OctezRollupConfig {
             binary_path: self


### PR DESCRIPTION
## Why

- The port configuration of the sandbox for rollup broke down, this PR fixes this
- We need a way to build docker images with configurable features e.g with or without sequencer

## Changes

- Replaced hardcoded `--features build-image --features v2_runtime --features sequencer` with configurable `FEATURES` arg
- Default features: `build-image,v2_runtime,sequencer` (preserves existing behavior)
- Set jstz sandbox rollup default port to 18751
- Set jstz node to use default run mode