### PR TITLE
feat(jstzd): make jstz node partially configurable

### DIFF
--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -61,12 +61,18 @@ impl AppState {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, clap::ValueEnum)]
+#[derive(Debug, Deserialize, Serialize, Clone, clap::ValueEnum, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum RunMode {
     Sequencer,
     #[serde(alias = "default")]
     Default,
+}
+
+impl Default for RunMode {
+    fn default() -> Self {
+        Self::Default
+    }
 }
 
 pub struct RunOptions {
@@ -247,6 +253,11 @@ mod test {
             current_spec == generated_spec,
             "API doc regression detected. Run the following to view the modifications:\n\tcargo run --bin jstz-node -- spec -o crates/jstz_node/openapi.json"
         );
+    }
+
+    #[test]
+    fn default_runmode() {
+        assert_eq!(RunMode::default(), RunMode::Default);
     }
 
     #[tokio::test]

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -54,7 +54,6 @@ tezos_crypto_rs.workspace = true
 skip-rollup-tests = []
 build-image = ["octez/disable-alpha"]
 v2_runtime = ["jstz_node/v2_runtime"]
-sequencer = []
 
 [[bin]]
 name = "jstzd"

--- a/crates/jstzd/Dockerfile
+++ b/crates/jstzd/Dockerfile
@@ -1,5 +1,5 @@
 ARG OCTEZ_VERSION=22.0
-ARG FEATURES="build-image,v2_runtime,sequencer"
+ARG FEATURES="build-image,v2_runtime"
 FROM rust:1.82.0-slim-bookworm AS builder
 RUN apt update && apt install -y curl pkg-config libssl-dev libsqlite3-dev
 

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+
+use jstz_node::RunMode;
 use octez::r#async::node_config::{OctezNodeHistoryMode, OctezNodeRunOptionsBuilder};
 use rust_embed::Embed;
 use tempfile::NamedTempFile;
@@ -76,6 +79,16 @@ pub struct BootstrapContractFile;
 #[include = "*.json"]
 struct BootstrapRollupFile;
 
+// A subset of JstzNodeConfig that is exposed to users.
+#[derive(Deserialize, Default, PartialEq, Debug)]
+struct UserJstzNodeConfig {
+    #[serde(default)]
+    mode: RunMode,
+    #[serde(default)]
+    capacity: usize,
+    debug_log_file: Option<PathBuf>,
+}
+
 #[derive(Deserialize, Default)]
 pub struct Config {
     server_port: Option<u16>,
@@ -86,6 +99,8 @@ pub struct Config {
     octez_client: Option<OctezClientConfigBuilder>,
     #[serde(default)]
     octez_rollup: Option<OctezRollupConfigBuilder>,
+    #[serde(default)]
+    jstz_node: UserJstzNodeConfig,
     #[serde(default)]
     protocol: ProtocolParameterBuilder,
 }
@@ -163,26 +178,21 @@ pub async fn build_config(mut config: Config) -> Result<(u16, JstzdConfig)> {
 
     let jstz_node_rpc_endpoint =
         Endpoint::try_from(Uri::from_static(DEFAULT_JSTZ_NODE_ENDPOINT)).unwrap();
-    let jstz_node_debug_file_path = NamedTempFile::new()
-        .context("failed to create jstz node debug file path")?
-        .into_temp_path()
-        .keep()
-        .context("failed to keep jstz node debug file path")?;
     let jstz_node_config = JstzNodeConfig::new(
         &jstz_node_rpc_endpoint,
         &octez_rollup_config.rpc_endpoint,
         &jstz_rollup_path::preimages_path(),
         &kernel_debug_file_path,
         KeyPair::default(),
-        #[cfg(feature = "sequencer")]
-        jstz_node::RunMode::Sequencer,
-        #[cfg(not(feature = "sequencer"))]
-        jstz_node::RunMode::Default,
-        #[cfg(feature = "sequencer")]
-        1024,
-        #[cfg(not(feature = "sequencer"))]
-        0,
-        &jstz_node_debug_file_path,
+        config.jstz_node.mode,
+        config.jstz_node.capacity,
+        &config.jstz_node.debug_log_file.unwrap_or(
+            NamedTempFile::new()
+                .context("failed to create jstz node debug file path")?
+                .into_temp_path()
+                .keep()
+                .context("failed to keep jstz node debug file path")?,
+        ),
     );
 
     let server_port = config.server_port.unwrap_or(DEFAULT_JSTZD_SERVER_PORT);
@@ -302,8 +312,11 @@ async fn build_protocol_params(
 mod tests {
     use std::{io::Read, io::Write, path::PathBuf, str::FromStr};
 
+    use crate::config::UserJstzNodeConfig;
+
     use super::{jstz_rollup_path, Config, JSTZ_ROLLUP_ADDRESS};
     use http::Uri;
+    use jstz_node::RunMode;
     use octez::r#async::{
         baker::{BakerBinaryPath, OctezBakerConfigBuilder},
         client::OctezClientConfigBuilder,
@@ -385,6 +398,18 @@ mod tests {
     }
 
     #[test]
+    fn user_jstz_node_config() {
+        assert_eq!(
+            UserJstzNodeConfig::default(),
+            UserJstzNodeConfig {
+                mode: RunMode::Default,
+                capacity: 0,
+                debug_log_file: None
+            }
+        )
+    }
+
+    #[test]
     fn deserialize_config_default() {
         let config = serde_json::from_value::<Config>(serde_json::json!({})).unwrap();
         assert_eq!(config.octez_baker, OctezBakerConfigBuilder::default());
@@ -392,6 +417,7 @@ mod tests {
         assert_eq!(config.octez_node, OctezNodeConfigBuilder::default());
         assert_eq!(config.protocol, ProtocolParameterBuilder::default());
         assert!(config.server_port.is_none());
+        assert_eq!(config.jstz_node, UserJstzNodeConfig::default());
     }
 
     #[test]
@@ -517,6 +543,40 @@ mod tests {
             serde_json::from_value::<Config>(serde_json::json!({"server_port":5678}))
                 .unwrap();
         assert_eq!(config.server_port, Some(5678));
+    }
+
+    #[test]
+    fn deserialize_config_jstz_node() {
+        let config = serde_json::from_value::<Config>(serde_json::json!({
+            "jstz_node": {
+                "mode": "sequencer",
+                "capacity": 42,
+                "debug_log_file": "/tmp/log"
+            }
+        }))
+        .unwrap();
+        assert_eq!(
+            config.jstz_node,
+            UserJstzNodeConfig {
+                mode: RunMode::Sequencer,
+                capacity: 42,
+                debug_log_file: Some(PathBuf::from_str("/tmp/log").unwrap())
+            }
+        );
+
+        // default
+        let config = serde_json::from_value::<Config>(serde_json::json!({
+            "jstz_node": {}
+        }))
+        .unwrap();
+        assert_eq!(
+            config.jstz_node,
+            UserJstzNodeConfig {
+                mode: RunMode::Default,
+                capacity: 0,
+                debug_log_file: None
+            }
+        );
     }
 
     #[test]
@@ -657,6 +717,11 @@ mod tests {
             },
             "protocol": {
                 "bootstrap_accounts": [["edpktkhoky4f5kqm2EVwYrMBq5rY9sLYdpFgXixQDWifuBHjhuVuNN", "6000000000"]]
+            },
+            "jstz_node": {
+                "mode": "sequencer",
+                "capacity": 42,
+                "debug_log_file": "/debug/file"
             }
         }))
         .unwrap();
@@ -702,6 +767,12 @@ mod tests {
         assert_eq!(
             config.jstz_node_config().rollup_endpoint,
             config.octez_rollup_config().rpc_endpoint
+        );
+        assert_eq!(config.jstz_node_config().mode, RunMode::Sequencer);
+        assert_eq!(config.jstz_node_config().capacity, 42);
+        assert_eq!(
+            config.jstz_node_config().debug_log_file,
+            PathBuf::from_str("/debug/file").unwrap()
         );
     }
 


### PR DESCRIPTION
# Context

Completes JSTZ-689.
[JSTZ-689](https://linear.app/tezos/issue/JSTZ-689/expose-jstz-node-config-in-jstzd)

Jstz node in jstzd needs to be at least partially configurable, e.g. for run mode and debug file.

# Description

Added `UserJstzNodeConfig`, a subset of jstz config only for jstzd, such that jstz node in jstzd is partially configurable.

Also removed the feature flag `sequencer` since it is no longer in use with the changes in this PR.

# Manually testing the PR

* Unit testing: added tests
* Manual testing: build and ran jstzd with the following config:
```
{"jstz_node":{"mode":"sequencer","debug_log_file":"/tmp/jstz_node_log", "capacity":42}}
```
and observed that jstz node indeed ran in sequencer mode and wrote logs to the file.
