### PR TITLE
chore(sequencer): use injector specified in config

### DIFF
--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -133,6 +133,7 @@ pub async fn run(
             worker::spawn(
                 queue.clone(),
                 runtime_db.clone(),
+                &injector,
                 rollup_preimages_dir.clone(),
                 Some(&debug_log_path),
             )
@@ -145,6 +146,7 @@ pub async fn run(
                 worker::spawn(
                     queue.clone(),
                     runtime_db.clone(),
+                    &injector,
                     rollup_preimages_dir.clone(),
                     Some(&debug_log_path),
                     move || {


### PR DESCRIPTION
# Context

Part of JSTZ-711.
[JSTZ-711](https://linear.app/tezos/issue/JSTZ-711/replace-injector)

Injector cannot be hardcoded either.

# Description

Updated the sequencer such that the internal runtime uses the injector public key from the node config instead of the hard-coded one.

# Manually testing the PR

All existing tests should pass.
