### PR TITLE
fix(jstzd): fix outdated integration test

### DIFF
--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -264,23 +264,23 @@ async fn fetch_config_test(jstzd_config: JstzdConfig, jstzd_port: u16) {
     let mut full_config = serde_json::json!({});
     for (key, expected_json) in [
         (
-            "octez-node",
+            "octez_node",
             serde_json::to_value(jstzd_config.octez_node_config()).unwrap(),
         ),
         (
-            "octez-client",
+            "octez_client",
             serde_json::to_value(jstzd_config.octez_client_config()).unwrap(),
         ),
         (
-            "octez-baker",
+            "octez_baker",
             serde_json::to_value(jstzd_config.baker_config()).unwrap(),
         ),
         (
-            "octez-rollup",
+            "octez_rollup",
             serde_json::to_value(jstzd_config.octez_rollup_config()).unwrap(),
         ),
         (
-            "jstz-node",
+            "jstz_node",
             serde_json::to_value(jstzd_config.jstz_node_config()).unwrap(),
         ),
     ] {

--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -69,7 +69,7 @@ pub async fn spawn_baker(
     octez_client: &OctezClient,
 ) -> octez_baker::OctezBaker {
     let baker_config = OctezBakerConfigBuilder::new()
-        .set_binary_path(BakerBinaryPath::Env(Protocol::Alpha))
+        .set_binary_path(BakerBinaryPath::Env(Protocol::default()))
         .set_octez_client_base_dir(
             PathBuf::from(octez_client.base_dir()).to_str().unwrap(),
         )


### PR DESCRIPTION
# Context

Integration tests in the crate `jstzd` are a bit outdated since they are excluded from CI due to the issue in running rollup nodes in the CI setup.

# Description

Updated the test `jstzd_test` so that it works again.

# Manually testing the PR

Ran the test locally.

`cd $(git rev-parse --show-toplevel)/crates/jstzd && cargo test --test jstzd_test`

