### PR TITLE
chore(docs): temporarily hide noop

### DIFF
--- a/docs/functions/tokens.md
+++ b/docs/functions/tokens.md
@@ -28,6 +28,7 @@ const send_request = new Request(`jstz://${smartFunctionB}`, {
 await fetch(send_request);
 ```
 
+<!-- Blocked by JSTZ-657
 To send tez to a smart function without calling the smart function and running its handler function, send the tez in a request to `jstz://<ADDRESS>/-/noop`, as in this example:
 
 ```typescript
@@ -38,6 +39,7 @@ const call_request = new Request(`jstz://${smart_function}/-/noop`, {
   },
 });
 ```
+-->
 
 As described in [Errors](/functions/errors), any transfers are reverted if a smart function throws an uncaught error.
 


### PR DESCRIPTION
# Context

`/-/noop` is not yet supported in v2 runtime.

# Description

Commented out the section about transferring tokens with the `/-/noop` endpoint.

# Manually testing the PR

Built docs locally and confirmed that the section was absent.
