### PR TITLE
fix(runtime): `self` should be `globalThis`

### DIFF
--- a/crates/jstz_runtime/src/ext/jstz_main/99_main.js
+++ b/crates/jstz_runtime/src/ext/jstz_main/99_main.js
@@ -2,7 +2,7 @@ import { workerGlobalScope } from "ext:jstz_main/98_global_scope.js";
 
 Object.defineProperties(globalThis, workerGlobalScope);
 Object.defineProperty(globalThis, "self", {
-  value: workerGlobalScope,
+  value: globalThis,
   configurable: false,
   enumerable: false,
   writable: false,


### PR DESCRIPTION
# Context

Part of JSTZ-772.
[JSTZ-772](https://linear.app/tezos/issue/JSTZ-772/fix-wpt)

# Description

Made `globalThis.self` point to `globalThis`.

According to the [spec](https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self),

> workerGlobal.[self](https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self)
> Returns workerGlobal.

I'm actually not very sure if using worker API here is appropriate as we don't actually support workers, but this is what was introduced in #1190 and it's mainly just about `self`, so I guess it's okay for now.

# Manually testing the PR

Tested the following smart function with jstzd:

```js
function a() {
  return new Response(globalThis === self);
}
export default a;
```

Before: the response was `false`
After: the response is `true`
