### PR TITLE
fix(docs): remove sidebar padding to match docs.tezos.com

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -154,17 +154,13 @@ nav.navbar {
   transition: color 0.3s;
 }
 
-/* Fixes because the carets aren't showing up for some reason */
-.menu__list > .theme-doc-sidebar-item-category {
-  padding-bottom: 25px;
-}
+/* Adjust styling of sidebar to bold headings */
 .menu__list
   > .theme-doc-sidebar-item-category
   .menu__list-item-collapsible
   .menu__link {
   font-weight: bold;
 }
-/* End fixes */
 
 .menu__link:hover,
 .menu__link:focus {


### PR DESCRIPTION
Restore the doc sidebar to remove the temporary padding that is no longer necessary and doesn't match docs.tezos.com. I'm leaving the bolding in there because we decided to add that to the Tezos docs: https://gitlab.com/tezos/docs/-/merge_requests/49

New appearance of sidebar:
<img width="309" height="611" alt="Screenshot 2025-08-26 at 9 50 23 AM" src="https://github.com/user-attachments/assets/3af2ee28-7dea-4a01-9809-e892df8a5e93" />
