### PR TITLE
chore(utils): make inbox builder optional

### DIFF
--- a/crates/jstz_tps_bench/Cargo.toml
+++ b/crates/jstz_tps_bench/Cargo.toml
@@ -18,7 +18,7 @@ bip39.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 jstz_proto = { path = "../jstz_proto" }
-jstz_utils = { path = "../jstz_utils" }
+jstz_utils = { path = "../jstz_utils", features = ["inbox_builder"] }
 tezos-smart-rollup = { workspace = true, features =  ["utils"] }
 tezos_data_encoding.workspace = true
 serde.workspace = true

--- a/crates/jstz_utils/Cargo.toml
+++ b/crates/jstz_utils/Cargo.toml
@@ -14,17 +14,17 @@ description = "Utility functions"
 anyhow.workspace = true
 futures.workspace = true
 futures-core.workspace = true
-http.workspace = true
+http = { workspace = true, optional = true }
 jstz_core   = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
-jstz_proto = { path = "../jstz_proto" }
+jstz_proto = { path = "../jstz_proto", optional = true }
 log.workspace = true
 reqwest.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tezos-smart-rollup = { workspace = true, features =  ["utils"] }
-tezos_data_encoding.workspace = true
+tezos-smart-rollup = { workspace = true, features =  ["utils"], optional = true }
+tezos_data_encoding = { workspace = true, optional = true }
 tokio.workspace = true
 tokio-util.workspace = true
 
@@ -34,4 +34,5 @@ tempfile.workspace = true
 url.workspace = true
 
 [features]
-v2_runtime = ["jstz_proto/v2_runtime"]
+v2_runtime = ["jstz_proto?/v2_runtime"]
+inbox_builder = ["dep:jstz_proto", "dep:http", "dep:tezos-smart-rollup", "dep:tezos_data_encoding"]

--- a/crates/jstz_utils/src/lib.rs
+++ b/crates/jstz_utils/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod event_stream;
 pub mod filtered_log_stream;
+#[cfg(feature = "inbox_builder")]
 pub mod inbox_builder;
 pub mod key_pair;
 pub mod tailed_file;


### PR DESCRIPTION
# Context

Part of JSTZ-841.
[JSTZ-841](https://linear.app/tezos/issue/JSTZ-841/implement-test-framework-for-dispatching-operations)

Should have been done in #1249. The inbox builder introduces a few heavy dependencies to the utils crate. This is one of the reasons that I didn't want to put this inbox builder in this utils crate.

# Description

Added a feature `inbox_builder` that gates the inbox builder implementation in `jstz_utils`, making the inbox builder and its dependencies deactivated by default. This helps reducing the amount of dependencies built as most crates depending on `jstz_utils` are not going to touch the inbox builder. 

# Manually testing the PR

Everything still builds.
