### PR TITLE
fix: correct key file docstring

### DIFF
--- a/crates/jstz_node/src/main.rs
+++ b/crates/jstz_node/src/main.rs
@@ -61,7 +61,7 @@ struct Args {
     #[arg(long)]
     debug_log_path: Option<PathBuf>,
 
-    /// Path to file containing injector key pair (format: {"public_key":...,"secret_key":...})
+    /// Path to file containing injector key pair (format: {"public_key": ..., "secret_key": ...})
     #[arg(long)]
     injector_key_file: PathBuf,
 }

--- a/crates/jstz_oracle_node/src/main.rs
+++ b/crates/jstz_oracle_node/src/main.rs
@@ -21,7 +21,7 @@ struct Args {
     #[arg(long, default_value = DEFAULT_JSTZ_NODE_ENDPOINT)]
     node_endpoint: String,
 
-    /// Path to file containing key pair (format: {"public_key":...,"secret_key":...})
+    /// Path to file containing key pair (format: {"public_key": ..., "secret_key": ...})
     #[arg(long)]
     key_file: PathBuf,
 }


### PR DESCRIPTION
# Context

Part of #1214 and #1257.

The format of the content of key files was updated in #1214 but the docstring was not updated accordingly.

# Description

Updated the outdated docstring for the content of key files. 

# Manually testing the PR

N/A
