### PR TITLE
fix(docs): correct path to web-call-to-jstz example

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -268,7 +268,7 @@ Follow these steps to run a sample web application that uses your smart function
 1. On the same system as you are running the Jstz sandbox, build and run the `web-call-to-jstz` sample application from the `dev-wallet` repository:
 
    ```sh
-   cd examples/web-call-to-jstz
+   cd apps/examples/web-call-to-jstz
    pnpm i
    pnpm dev
    ```


### PR DESCRIPTION
The path to the wallet web example has changed to `apps/examples/web-call-to-jstz`. See https://github.com/jstz-dev/dev-wallet/tree/main/apps/examples/web-call-to-jstz.