### PR TITLE
feat(ci): job for running wpt tests in risc-v sandbox nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,36 +47,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  wpt_riscv:
-    name: Web Platform Test (RISC-V)
-    runs-on: wpt
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Build RISCV WPT kernel
-        run: nix --accept-flake-config --log-format raw -L develop -j auto --command make riscv-wpt-test-kernel
-      - name: Setup WPT test server
-        run: |
-          cd crates/jstz_wpt/wpt && python3 wpt make-hosts-file >> /etc/hosts
-          python3 wpt serve &
-      - name: Download Deno test baseline
-        run: |
-          cd crates/jstz_runtime
-          curl -s --output tests/deno_report.json https://storage.googleapis.com/wptd-results/e78446e34a1921371658a5df08c71d83f50a2a2f/deno-2.1.10_4921411-linux-unknown-fccd901f99/report.json
-      - name: Execute WPT tests
-        run: |
-          nix --accept-flake-config --log-format raw -L develop -j auto --command sh -c '
-          cd crates/jstz_runtime
-          STATS_PATH=$(pwd)/out.txt cargo test --features wpt-in-riscv --test wpt -- --nocapture
-          '
-      - name: Collect and display test results
-        run: |
-          cd crates/jstz_runtime
-          while read line; do
-            echo "$line" >> $GITHUB_STEP_SUMMARY
-          done < $(pwd)/out.txt
-
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Context
[JSTZ-882](https://linear.app/tezos/issue/JSTZ-882/ci-for-wpt-tests-in-riscv-sandbox)

# Description
This PR adds job for running wpt tests in riscv sandbox nightly. The execution of tests is using riscv-sandbox and thus needs to be run in nix environment.

# Testing
[Test run](https://github.com/jstz-dev/jstz/actions/runs/17913034691/job/50928727330?pr=1277)
