### PR TITLE
chore(sequencer): extend integration test waiting time

### DIFF
--- a/crates/jstz_node/tests/sequencer.rs
+++ b/crates/jstz_node/tests/sequencer.rs
@@ -166,7 +166,7 @@ async fn run_riscv_sequencer() {
 }
 
 async fn check_mode(client: &Client, base_uri: &str) {
-    let res = jstz_utils::poll(15, 500, || async {
+    let res = jstz_utils::poll(60, 500, || async {
         client.get(format!("{base_uri}/mode")).send().await.ok()
     })
     .await
@@ -440,7 +440,7 @@ fn mock_fa_deposit_op_hash_matches_actual_hash() {
 }
 
 async fn check_worker_health(client: &Client, base_uri: &str) {
-    let res = jstz_utils::poll(20, 500, || async {
+    let res = jstz_utils::poll(60, 500, || async {
         client
             .get(format!("{base_uri}/worker/health"))
             .send()


### PR DESCRIPTION
# Context

Sequencer nightly test suffers from [transient failures](https://github.com/jstz-dev/jstz/actions/runs/17966547760/attempts/1).

# Description

Updated the test with more retry attempts, specifically for retrieving receipts and checking worker health. Loading the RISCV kernel takes a bit of time, especially on not so great machines, so this will hopefully prevent the test from erroring out too soon.

# Manually testing the PR

Ran the RISCV sequencer test locally without any issue.
