### PR TITLE
feat: generate and use runtime snapshot in kernel

### DIFF
--- a/crates/jstz_proto/src/runtime/mod.rs
+++ b/crates/jstz_proto/src/runtime/mod.rs
@@ -7,6 +7,6 @@ pub use v1::{run_toplevel_fetch, Kv, KvValue, LogRecord, ParsedCode, LOG_PREFIX}
 pub mod v2;
 #[cfg(feature = "v2_runtime")]
 pub use v2::{
-    protocol_context::*, run_toplevel_fetch, Kv, KvValue, LogRecord, ParsedCode,
-    LOG_PREFIX,
+    fetch::fetch_handler::ProtoFetchHandler, protocol_context::*, run_toplevel_fetch, Kv,
+    KvValue, LogRecord, ParsedCode, LOG_PREFIX, SNAPSHOT,
 };

--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -7,6 +7,7 @@ use crate::runtime::v2::fetch::error::{FetchError, Result};
 use crate::runtime::v2::fetch::http::Request;
 use crate::runtime::v2::ledger;
 use crate::runtime::v2::protocol_context::PROTOCOL_CONTEXT;
+use crate::runtime::SNAPSHOT;
 
 use deno_core::error::CoreError;
 use deno_core::{
@@ -529,6 +530,7 @@ async fn load_and_run(
         fetch: ProtoFetchHandler,
         protocol: Some(proto),
         extensions: vec![ledger::jstz_ledger::init_ops_and_esm()],
+        snapshot: SNAPSHOT.get().map(|v| *v),
     });
     runtime.set_state(source);
 
@@ -1867,6 +1869,7 @@ mod test {
             fetch: ProtoFetchHandler,
             module_loader: Rc::new(module_loader),
             extensions: vec![],
+            snapshot: None,
         });
         runtime.set_state(SourceAddress::try_from(source).unwrap());
         let id = runtime.execute_main_module(&specifier).await.unwrap();

--- a/crates/jstz_proto/src/runtime/v2/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use crate::{
     context::account::Addressable,
     operation::{OperationHash, RunFunction},
@@ -22,6 +24,8 @@ pub use parsed_code::ParsedCode;
 mod ledger;
 pub mod oracle;
 pub mod protocol_context;
+
+pub static SNAPSHOT: OnceLock<&'static [u8]> = OnceLock::new();
 
 pub async fn run_toplevel_fetch(
     hrt: &mut impl HostRuntime,


### PR DESCRIPTION
# Context

Loading, parsing, and compiling JavaScript at runtime is expensive. V8’s snapshot mechanism allows the engine to start from a pre-initialized state, eliminating this overhead. Using snapshots yielded a 5× increase in transactions per second.

Closes: https://linear.app/tezos/issue/JSTZ-790/snapshot-jsruntime
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
1. Add generate_snapshot helper to JstzRuntime
2. Set global `OnceLock` `SNAPSHOT` variable
3. Update `JstzRuntimeOptions` to take a snapshot as input and initialize use snapshot if available in `load_and_run`
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make`

__Old TPS__
10 FA2 transfers took 8.557973791s @ 1.169 TPS

__New TPS__
10 FA2 transfers took 1.953596735s @ 5.119 TPS

<!-- Describe how reviewers and approvers can test this PR. -->
