### PR TITLE
chore: bump octez to v23.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
       - id: run
         run: |
           input_tag=${{ inputs.octez-tag }}
-          octez_tag=${input_tag:-"23.1"}
+          octez_tag=${input_tag:-"23.2"}
           echo "OCTEZ_TAG=${octez_tag}" >> ${GITHUB_OUTPUT}
   build-kernel:
     name: Build (Kernel)

--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -522,7 +522,7 @@ mod test {
             start_server_with_storage_sync(port, &kernel_log_file, RunMode::Default);
 
         // wait for the server to start
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(3)).await;
 
         let storage_updates = sets_balance(addr.clone(), amount);
         // write a storage update that deposits the `amount` to the `addr`
@@ -533,7 +533,7 @@ mod test {
         ));
 
         // Check that the storage update is applied to the database
-        timeout(Duration::from_secs(1), async {
+        timeout(Duration::from_secs(3), async {
             loop {
                 let b = reqwest::get(format!(
                     "http://0.0.0.0:{port}/accounts/{addr}/balance"

--- a/crates/jstzd/Dockerfile
+++ b/crates/jstzd/Dockerfile
@@ -1,4 +1,4 @@
-ARG OCTEZ_VERSION=23.1
+ARG OCTEZ_VERSION=23.2
 ARG FEATURES="build-image,oracle"
 FROM rust:1.86.0-slim-bookworm AS builder
 RUN apt update && apt install -y curl pkg-config libssl-dev libsqlite3-dev
@@ -24,8 +24,7 @@ RUN apt update && apt install -y curl gpg && \
     curl -s "https://packages.nomadic-labs.com/debian/octez.asc" | gpg --dearmor -o /etc/apt/keyrings/octez.gpg && \
     # FIXME(https://linear.app/tezos/issue/JSTZ-901/verify-nl-package-in-jstzd-dockerfile)
     # Set trusted=yes to skip signing as it is currently broken
-    # echo "deb [signed-by=/etc/apt/keyrings/octez.gpg] https://packages.nomadic-labs.com/debian bookworm main" | tee /etc/apt/sources.list.d/octez.list && \
-    echo "deb [trusted=yes] https://packages.nomadic-labs.com/debian bookworm main" | tee /etc/apt/sources.list.d/octez.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/octez.gpg] https://packages.nomadic-labs.com/debian bookworm main" | tee /etc/apt/sources.list.d/octez.list && \
     apt-get update && echo $'\n\n\n\n' | apt -y install octez-node=${OCTEZ_VERSION} \
         octez-client=${OCTEZ_VERSION} octez-baker=${OCTEZ_VERSION} \
         octez-smart-rollup-node=${OCTEZ_VERSION} && \


### PR DESCRIPTION
# Context
[Octez 23.1 has been pulled from archives](https://forum.tezosagora.org/t/announcing-octez-v23-2/6887)

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Bumped octez version 
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`docker build -f crates/jstzd/Dockerfile -t jstzd --build-arg KERNEL_PATH=crates/jstzd/resources/jstz_rollup/jstz_kernel.wasm .`
<!-- Describe how reviewers and approvers can test this PR. -->
