### PR TITLE
fix: map cli version 0.1.1-alpha.4.1 to 0.1.1-alpha.4

### DIFF
--- a/packages/cli/main/install.js
+++ b/packages/cli/main/install.js
@@ -55,11 +55,17 @@ try {
 
   await fsPromises.mkdir(BIN_DIR, { recursive: true });
 
-  if (!packageJson.version) {
+  let version = packageJson.version;
+  if (!version) {
     throw new Error("The 'version' field was not found in package.json");
   }
 
-  const url = `https://github.com/jstz-dev/jstz/releases/download/${packageJson.version}/${binaryName}`;
+  // Map 0.1.1-alpha.4.1 to 0.1.1-alpha.4
+  if (version == "0.1.1-alpha.4.1") {
+    version = "0.1.1-alpha.4";
+  }
+
+  const url = `https://github.com/jstz-dev/jstz/releases/download/${version}/${binaryName}`;
 
   console.log(`Downloading ${binaryName} from ${url}`);
 

--- a/packages/cli/main/package.json
+++ b/packages/cli/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jstz-dev/cli",
-  "version": "0.1.1-alpha.4",
+  "version": "0.1.1-alpha.4.1",
   "description": "A command-line interface for jstz.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
# Context
NPM doesn't allow us to override existing packages and it is too late to unpublish  them so we need to release a new version. We want to release a new version of cli but point it to the current 0.1.1-alpha.4 binaries


<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Maps  0.1.1-alpha.4.1 to 0.1.1-alpha.4 binary

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
```
λ yarn global add file:/Users/ryan-tan/workspace/jstz/packages/cli/main

λ ~/.yarn/bin/jstz --version
jstz 0.1.1-alpha.4
```


<!-- Describe how reviewers and approvers can test this PR. -->
