### PR TITLE
feat(proto): reveal oracle request for simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ test-unit-v2:
 # --lib only runs unit tests in library crates
 # --bins only runs unit tests in binary crates
 	@cargo nextest run --lib --bins --workspace --exclude "jstz_tps_bench" --features v2_runtime,skip-wpt,skip-rollup-tests --config-file .config/nextest.toml
+	@cargo nextest run -p jstz_proto --features v2_runtime,simulation --config-file .config/nextest.toml
 
 .PHONY: test-int
 test-int-v2:

--- a/crates/jstz_core/src/lib.rs
+++ b/crates/jstz_core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod log_record;
 pub mod native;
 pub mod realm;
 pub mod reveal_data;
+mod revealer;
 pub mod runtime;
 #[cfg(feature = "simulation")]
 pub mod simulation;
@@ -25,4 +26,5 @@ pub trait Api {
 }
 
 pub use realm::{Module, Realm};
+pub use revealer::Revealer;
 pub use runtime::Runtime;

--- a/crates/jstz_core/src/revealer.rs
+++ b/crates/jstz_core/src/revealer.rs
@@ -1,0 +1,18 @@
+use crate::host::HostError;
+
+/// A type that can load the result of `request` into `response` from the host.
+pub trait Revealer {
+    /// # Safety
+    ///
+    /// The host has to handle the reveal request and response accordingly.
+    unsafe fn reveal(
+        request: &[u8],
+        response: &mut [u8],
+    ) -> std::result::Result<usize, HostError>;
+}
+
+impl Revealer for () {
+    unsafe fn reveal(_: &[u8], _: &mut [u8]) -> std::result::Result<usize, HostError> {
+        unimplemented!()
+    }
+}

--- a/crates/jstz_core/src/simulation/jstz_reveal.rs
+++ b/crates/jstz_core/src/simulation/jstz_reveal.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::BinEncodable;
+use crate::{BinEncodable, Revealer};
 use tezos_smart_rollup::host::RuntimeError;
 use tezos_smart_rollup_constants::riscv::REVEAL_REQUEST_MAX_SIZE;
 
@@ -10,13 +10,6 @@ pub const JSTZ_REVEAL_TAG: u8 = 0xFF;
 pub enum JstzRevealError {
     #[error("Jstz reveal data size exceeds the maximum limit.")]
     RevealSizeExceedsMaximumLimit,
-}
-
-pub trait Revealer {
-    unsafe fn reveal(
-        request: &[u8],
-        response: &mut [u8],
-    ) -> std::result::Result<usize, RuntimeError>;
 }
 
 /// The host revealer that loads the result of a raw reveal request to memory.
@@ -117,15 +110,6 @@ mod tests {
         type Target = [u8];
         fn deref(&self) -> &Self::Target {
             &self.0
-        }
-    }
-
-    impl Revealer for () {
-        unsafe fn reveal(
-            _: &[u8],
-            _: &mut [u8],
-        ) -> std::result::Result<usize, RuntimeError> {
-            unimplemented!()
         }
     }
 

--- a/crates/jstz_proto/src/runtime/v2/fetch/http.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/http.rs
@@ -59,6 +59,17 @@ impl PartialEq for Response {
     }
 }
 
+impl From<jstz_core::Error> for Response {
+    fn from(value: jstz_core::Error) -> Self {
+        Response {
+            status: 500,
+            status_text: "Internal Server Error".into(),
+            headers: Vec::new(),
+            body: Body::Vector(value.to_string().into_bytes()),
+        }
+    }
+}
+
 impl Into<http::Response<Option<Vec<u8>>>> for Response {
     fn into(self) -> http::Response<Option<Vec<u8>>> {
         // According to JavaScript documentation, `Response.error()` returns a response with status code 0


### PR DESCRIPTION
# Context

This is the final step enable oracle simulation in the kernel.

Closes: [JSTZ-1048](https://linear.app/tezos/issue/JSTZ-1048/reveal-oracle-request)

# Description
* **Moved `Revealer` trait to `jstz_core`**: This makes the trait available for both simulation and non-simulation modes.

* **Refactored `process_and_dispatch_request`**: Split the implementation into:
  - `process_and_dispatch_request_impl<Rv: Revealer>` - A generic implementation that accepts any type implementing `Revealer`
  - Two feature-gated wrapper functions `process_and_dispatch_request` that call the impl with:
    - `HostRevealer` for simulation mode (uses reveal channel for oracle requests)
    - `()` stub type for non-simulation mode (oracle requests use protocol context instead )

* **Added simulation oracle dispatch**: Implemented `dispatch_oracle::<Rv>` for simulation mode that encodes HTTP requests and sends them via the reveal channel using `simulation::send_request`.

* **Added error conversion**: Implemented `From<jstz_core::Error>` for `Response` to handle reveal channel error.

* **Cleaned up the imports of `fetch_handler.rs`**: grouped the imports by crates

* **Updated Makefile to run proto test with the simulation feature**

# Manually testing the PR
* existing test passes
* cargo nextest run -p jstz_proto --features v2_runtime,simulation
