### PR TITLE
feat(node): add simulation mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-http",
+ "url",
  "utoipa",
  "utoipa-axum",
  "utoipa-scalar",

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -56,6 +56,7 @@ tokio-util.workspace = true
 tokio.workspace = true
 tower.workspace = true
 tower-http.workspace = true
+url.workspace = true
 utoipa.workspace = true
 utoipa-axum.workspace = true
 utoipa-scalar.workspace = true

--- a/crates/jstz_node/src/config.rs
+++ b/crates/jstz_node/src/config.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 use tezos_crypto_rs::hash::SmartRollupHash;
 
+use crate::simulation::config::SimulationConfig;
+
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[serde(tag = "type")]
@@ -187,6 +189,8 @@ pub struct JstzNodeConfig {
     /// Path to the sqlite db file that keeps the runtime state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_db_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub simulation: Option<SimulationConfig>,
 }
 
 impl JstzNodeConfig {
@@ -203,6 +207,7 @@ impl JstzNodeConfig {
         injector: KeyPair,
         mode: RunMode,
         storage_sync: bool,
+        simulation: Option<SimulationConfig>,
     ) -> Self {
         Self {
             endpoint: endpoint.clone(),
@@ -213,6 +218,7 @@ impl JstzNodeConfig {
             mode,
             storage_sync,
             runtime_db_path: None,
+            simulation,
         }
     }
 }
@@ -244,6 +250,7 @@ mod tests {
             ),
             RunMode::Default,
             true,
+            None,
         );
 
         let json = serde_json::to_value(&config).unwrap();

--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -25,6 +25,7 @@ use tower_http::cors::{Any, CorsLayer};
 
 mod api_doc;
 mod services;
+pub mod simulation;
 pub mod storage_sync;
 use services::Service;
 use utoipa::OpenApi;
@@ -34,7 +35,7 @@ pub mod config;
 pub mod sequencer;
 pub use config::RunMode;
 
-use crate::config::RuntimeEnv;
+use crate::{config::RuntimeEnv, simulation::config::SimulationConfig};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -76,6 +77,7 @@ pub struct RunOptions {
     pub mode: RunMode,
     pub storage_sync: bool,
     pub runtime_db_path: Option<PathBuf>,
+    pub simulation: Option<SimulationConfig>,
 }
 
 pub async fn run_with_config(config: JstzNodeConfig) -> Result<()> {
@@ -92,6 +94,7 @@ pub async fn run_with_config(config: JstzNodeConfig) -> Result<()> {
         mode: config.mode,
         storage_sync: config.storage_sync,
         runtime_db_path: config.runtime_db_path,
+        simulation: config.simulation,
     })
     .await
 }
@@ -107,6 +110,7 @@ pub async fn run(
         mode,
         storage_sync,
         runtime_db_path,
+        ..
     }: RunOptions,
 ) -> Result<()> {
     let rollup_client = OctezRollupClient::new(rollup_endpoint.to_string());
@@ -383,6 +387,7 @@ mod test {
                 mode: mode.clone(),
                 storage_sync: false,
                 runtime_db_path: None,
+                simulation: None,
             }));
 
             let res = jstz_utils::poll(10, 500, || async {
@@ -439,6 +444,7 @@ mod test {
                 mode,
                 storage_sync: false,
                 runtime_db_path: None,
+                simulation: None,
             }));
 
             sleep(Duration::from_secs(1)).await;
@@ -532,6 +538,7 @@ mod test {
             mode,
             storage_sync: true,
             runtime_db_path: None,
+            simulation: None,
         }))
     }
 

--- a/crates/jstz_node/src/main.rs
+++ b/crates/jstz_node/src/main.rs
@@ -10,6 +10,7 @@ use jstz_node::{
 };
 use jstz_utils::key_pair::parse_key_file;
 use tezos_crypto_rs::hash::SmartRollupHash;
+use url::Url;
 
 const DEFAULT_ROLLUP_NODE_RPC_ADDR: &str = "127.0.0.1";
 const DEFAULT_ROLLUP_RPC_PORT: u16 = 8932;
@@ -81,6 +82,18 @@ struct Args {
 
     #[arg(long)]
     inbox_checkpoint_path: Option<PathBuf>,
+
+    // Enables simulation of operations
+    #[arg(long, action = ArgAction::SetFalse, requires_all = ["sequencer_endpoint", "simulation_kernel_path"])]
+    enable_simulation: bool,
+
+    // Sequencer endpoint to listen for included operations. Required when simulation is enabled
+    #[arg(long)]
+    sequencer_endpoint: Option<Url>,
+
+    // Path to RISC-V simulation kernel. Required when simulation is enabled
+    #[arg(long)]
+    simulation_kernel_path: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -119,6 +132,7 @@ async fn main() -> anyhow::Result<()> {
                 mode: run_mode_builder.build()?,
                 storage_sync: args.storage_sync,
                 runtime_db_path: args.runtime_db_path,
+                simulation: None,
             })
             .await
         }

--- a/crates/jstz_node/src/simulation/config.rs
+++ b/crates/jstz_node/src/simulation/config.rs
@@ -1,0 +1,4 @@
+use serde::Serialize;
+
+#[derive(Clone, Serialize)]
+pub struct SimulationConfig;

--- a/crates/jstz_node/src/simulation/mod.rs
+++ b/crates/jstz_node/src/simulation/mod.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -239,6 +239,7 @@ fn build_jstz_node_config(
         injector.clone(),
         run_mode_builder.build()?,
         config.storage_sync,
+        None,
     ))
 }
 

--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -904,6 +904,7 @@ mod tests {
                     inbox_checkpoint_path: PathBuf::from("/inbox/checkpoint"),
                 },
                 false,
+                None,
             )),
             ProtocolParameterBuilder::new()
                 .set_bootstrap_accounts([BootstrapAccount::new(

--- a/crates/jstzd/tests/jstz_node_test.rs
+++ b/crates/jstzd/tests/jstz_node_test.rs
@@ -30,6 +30,7 @@ async fn jstz_node_test() {
         ),
         jstz_node::RunMode::Default,
         false,
+        None,
     );
     let mut jstz_node = jstzd::task::jstz_node::JstzNode::spawn(jstz_node_config)
         .await

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -196,6 +196,7 @@ async fn create_jstzd_server(
         ),
         jstz_node::RunMode::Default,
         false,
+        None,
     );
     let config = JstzdConfig::new(
         octez_node_config,


### PR DESCRIPTION
# Context
Closes [JSTZ-1001](https://linear.app/tezos/issue/JSTZ-1001/add-enable-simulationin-jstz-node)

This PR is the set up required for [JSTZ-1003](https://linear.app/tezos/issue/JSTZ-1003/implement-simulation-request-channel-in-worker) and [JSTZ-1004](https://linear.app/tezos/issue/JSTZ-1004/implement-post-simulate)

# Description
Adds `enable_simulation` flag to jstz node. 

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
Current tests still run
`make`
<!-- Describe how reviewers and approvers can test this PR. -->
