### PR TITLE
chore(build): merge riscv kernel build into main job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: nix --accept-flake-config fmt -- --fail-on-change
       - name: Prevent blst
         run: nix -L --accept-flake-config develop --no-sandbox -j auto --command sh -c '[ -z "$(cargo tree | grep blst)" ]'
+      - name: Build RISCV kernel
+        uses: ./.github/actions/build-riscv-kernel
       - name: Build
         run: nix --accept-flake-config --log-format raw -L build -j auto .#all
       - name: Flake check
@@ -76,10 +78,3 @@ jobs:
 
       - name: Build
         run: npm run docs:build
-
-  build-riscv-kernel:
-    name: Build RISCV kernel
-    runs-on: [linux, nix]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/build-riscv-kernel


### PR DESCRIPTION
# Context

With `build-riscv-kernel` being a separate job in the CI workflow as introduced in #1321, each CI run occupies 2 self-hosted nix workers, which is not fair for other users. `build-riscv-kernel` does not need to be a standalone job anyway.

# Description

Merged the job `build-riscv-kernel` into the main `build` job in the CI workflow.

# Manually testing the PR

The [build job](https://github.com/jstz-dev/jstz/actions/runs/20240122345/job/58105609879) still runs and includes one new step `Build RISCV kernel`.
