### PR TITLE
fix(build): correct misplaced text in prod doc workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@ on:
         description: "ref (branch, tag, or SHA) that will be used to build docs"
         type: string
       dry_run:
-        description: Dry-run SDK build without publishing the built artefact
+        description: Dry-run doc build without publishing the built artefact
         type: boolean
         required: false
         default: true
@@ -23,7 +23,7 @@ on:
         description: "ref (branch, tag, or SHA) that will be used to build docs"
         type: string
       dry_run:
-        description: Dry-run SDK build without publishing the built artefact
+        description: Dry-run doc build without publishing the built artefact
         type: boolean
         required: false
         default: true


### PR DESCRIPTION
# Context

The description for the `dry_run` option is wrong. It was copied from the sdk workflow in #1379 but wasn't updated accordingly.

# Description

Corrected the misplaced text.

# Manually testing the PR

N/A
