### PR TITLE
fix(build): fix riscv nightly test

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -57,8 +57,8 @@ jobs:
   sequencer_riscv_test:
     name: Run sequencer RISCV test
     runs-on: [large, nix]
-    needs: [build_riscv_kernel]
     steps:
+      - uses: actions/checkout@v6
       - name: Build kernel
         shell: bash
         # ticketer address must match the one specified in the test


### PR DESCRIPTION
# Context

Nightly test [failed](https://github.com/jstz-dev/jstz/actions/runs/20499267945/job/58904862612). 

# Description

Fixed the nightly test workflow by adding one line back. The checkout line should not have been removed in #1429. Without that, the runner somehow used an old version of the source code and that failed the test. The `needs` line is what should have been removed instead as the riscv test job no longer depends on the generic kernel.

# Manually testing the PR

[Test run](https://github.com/jstz-dev/jstz/actions/runs/20571691180/job/59080064177)
